### PR TITLE
Add token command

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -11,7 +11,6 @@ module ErrorHandler
     rescue_from UnauthorizedError, with: :handle_unauthorized
     rescue_from TokenUsedError, with: :handle_token_used
     rescue_from TokenExpiredError, with: :handle_token_expired
-    rescue_from TokenActivatedError, with: :handle_token_activated
     rescue_from InsufficientCreditsError, with: :handle_insufficient_credits
   end
 
@@ -51,10 +50,6 @@ module ErrorHandler
 
   def handle_token_expired(_error)
     respond_with :message, text: I18n.t("errors.token_expired")
-  end
-
-  def handle_token_activated(_error)
-    respond_with :message, text: I18n.t("errors.token_activated")
   end
 
   def handle_insufficient_credits(_error)

--- a/app/controllers/telegram_webhooks_controller.rb
+++ b/app/controllers/telegram_webhooks_controller.rb
@@ -11,16 +11,22 @@ class TelegramWebhooksController < Telegram::Bot::UpdatesController
       name: chat["first_name"]
     )
 
-    raise handled_token.error if handled_token.failure?
+    respond_with :message, text: start_message_for(handled_token)
+  end
+
+  def token!
+    session[:command] = "token"
+
+    respond_with :message, text: I18n.t("telegram_webhooks.commands.token.ask")
   end
 
   def message(user_message)
-    handled_message = MessageHandler::HandleMessage.call(
+    Telegram::MessageDispatcher.call(
+      command: session[:command],
+      chat_id: chat["id"],
       user_message:,
-      command: session[:command]
+      name: chat["first_name"]
     )
-
-    raise handled_message.error if handled_message.failure?
   end
 
   def prompt_to_video!(*)
@@ -87,5 +93,14 @@ class TelegramWebhooksController < Telegram::Bot::UpdatesController
 
   memoize def user
     User.eager_load(:balance).find_by(chat_id: chat["id"])
+  end
+
+  def start_message_for(handled_token)
+    if handled_token.success?
+      t("telegram_webhooks.commands.start.with_valid_token",
+        credits: handled_token.token.credits)
+    else
+      t("telegram_webhooks.commands.start.no_token")
+    end
   end
 end

--- a/app/errors/token_activated_error.rb
+++ b/app/errors/token_activated_error.rb
@@ -1,1 +1,0 @@
-class TokenActivatedError < StandardError; end

--- a/app/interactors/token_handler/notify_user.rb
+++ b/app/interactors/token_handler/notify_user.rb
@@ -6,7 +6,19 @@ module TokenHandler
     delegate :greeting, to: :token
 
     def call
-      ::Telegram.bot.send_message(chat_id:, text: greeting || I18n.t("telegram_webhooks.commands.start"))
+      ::Telegram.bot.send_message(chat_id:, text:)
+    end
+
+    private
+
+    def text
+      return default_text unless greeting.present?
+
+      "#{greeting}\n\n#{default_text}"
+    end
+
+    def default_text
+      I18n.t("telegram_webhooks.commands.token.activated", credits: token.credits)
     end
   end
 end

--- a/app/interactors/token_handler/verify_token.rb
+++ b/app/interactors/token_handler/verify_token.rb
@@ -15,7 +15,6 @@ module TokenHandler
 
     def validate_token!
       context.fail!(error: TokenNotFoundError) unless token
-      context.fail!(error: TokenActivatedError) if token.activated?
       context.fail!(error: TokenUsedError) if token.used_at.present?
       context.fail!(error: TokenExpiredError) if token.expired?
     end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -4,8 +4,4 @@ class Token < ApplicationRecord
   def expired?
     expires_at < Date.current
   end
-
-  def activated?
-    user_id.present?
-  end
 end

--- a/app/services/telegram/message_dispatcher.rb
+++ b/app/services/telegram/message_dispatcher.rb
@@ -1,0 +1,33 @@
+module Telegram
+  class MessageDispatcher
+    TOKEN_COMMAND = "token".freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(command:, chat_id:, user_message:, name:)
+      @command = command
+      @chat_id = chat_id
+      @user_message = user_message
+      @name = name
+    end
+
+    def call
+      raise handled_command.error if handled_command.failure?
+    end
+
+    private
+
+    attr_reader :command, :chat_id, :user_message, :name
+
+    def handled_command
+      case command
+      when TOKEN_COMMAND
+        TokenHandler::HandleToken.call(chat_id:, token_code: user_message["text"], name:)
+      else
+        MessageHandler::HandleMessage.call(command:, user_message:)
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,12 +1,50 @@
 en:
   telegram_webhooks:
     commands:
-      start: Hi there! Please choose a command from the menu list.
+      start: 
+        no_token: |
+          👋 Hi! Great to see you here.
+
+          🤖 With this bot, you can generate images and videos using different AI models.
+
+          🎨 To generate an image, type:
+          /prompt_to_image
+
+          🎬 To generate a video, type:
+          /prompt_to_video
+
+          💰 To check your balance, type:
+          /balance
+
+          🔑 To activate a token, type:
+          /token
+
+          ℹ️ Each generation costs credits.
+          To top up your balance, use /token and enter a valid token.
+
+          Tokens are provided by the administrator.
+        with_valid_token: |
+          🤖 With this bot, you can generate images and videos using different AI models.
+
+          🎨 To generate an image:
+          /prompt_to_image
+
+          🎬 To generate a video:
+          /prompt_to_video
+
+          💰 To check your balance:
+          /balance
       prompt_to_video: "Great! Now please provide a prompt for the video. The prompt can be in any language and any length, and it can later be adapted with the help of the bot."
       prompt_to_image: "Great! Now please provide a prompt for the image. The prompt can be in any language and any length, and it can later be adapted with the help of the bot."
       image_to_video: "Great! Now please send me the image you want to turn into a video."
       image_from_reference: "Great! Now please send me the reference image you want to use to generate a new image."
       balance: "Your current balance is %{balance} credits."
+      token:
+        ask: "Please enter your token to activate it:"
+        activated: |
+          ✅ Your token has been successfully activated!
+
+          🎉 You have received %{credits} credits.
     message:
       prompt_prefix: "Here is your prompt:"
       prompt_suffix: What do you want to do next?
@@ -28,7 +66,6 @@ en:
     token_not_found: "Sorry, the token you provided is invalid. You can ask administrator for a valid token."
     token_used: "Sorry, the token you provided has already been used."
     token_expired: "Sorry, the token you provided has expired."
-    token_activated: "Hey, seems like you already have an active subscription :) Please choose a command and enjoy the bot!"
     insufficient_credits: "Sorry, it looks like you don't have enough credits to perform this action :("
   telegram:
     generation:

--- a/spec/app/interactors/token_handler/notify_user_spec.rb
+++ b/spec/app/interactors/token_handler/notify_user_spec.rb
@@ -4,13 +4,21 @@ describe TokenHandler::NotifyUser do
   subject { described_class.call(chat_id:, token:) }
 
   let(:chat_id) { 456 }
-  let(:token) { create(:token, greeting: "Welcome!") }
+  let(:token) { create(:token, greeting: "Welcome!", credits: 100) }
 
   describe "#call" do
-    it "sends greeting message via Telegram" do
+    it "sends greeting and activated message via Telegram" do
+      activated_text =
+        I18n.t(
+          "telegram_webhooks.commands.token.activated",
+          credits: token.credits
+        )
+
+      expected_text = "Welcome!\n\n#{activated_text}"
+
       expect(Telegram.bot).to receive(:send_message).with(
-        chat_id: chat_id,
-        text: "Welcome!"
+        chat_id:,
+        text: expected_text
       )
 
       subject
@@ -23,14 +31,18 @@ describe TokenHandler::NotifyUser do
     end
 
     context "when greeting is nil" do
-      let(:token) { create(:token, greeting: nil) }
+      let(:token) { create(:token, greeting: nil, credits: 100) }
 
-      it "sends default start message" do
-        default_text = I18n.t("telegram_webhooks.commands.start")
+      it "sends default activated message" do
+        activated_text =
+          I18n.t(
+            "telegram_webhooks.commands.token.activated",
+            credits: token.credits
+          )
 
         expect(Telegram.bot).to receive(:send_message).with(
-          chat_id: chat_id,
-          text: default_text
+          chat_id:,
+          text: activated_text
         )
 
         subject

--- a/spec/app/interactors/token_handler/verify_token_spec.rb
+++ b/spec/app/interactors/token_handler/verify_token_spec.rb
@@ -17,18 +17,6 @@ describe TokenHandler::VerifyToken do
       end
     end
 
-    context "when token is activated" do
-      let(:user) { create(:user) }
-      let!(:token) { create(:token, user:) }
-
-      it "fails with TokenActivatedError" do
-        result = subject
-
-        expect(result).to be_failure
-        expect(result.error).to eq(TokenActivatedError)
-      end
-    end
-
     context "when token is already used" do
       let!(:token) { create(:token, used_at: Date.current) }
 

--- a/spec/app/models/token_spec.rb
+++ b/spec/app/models/token_spec.rb
@@ -30,23 +30,4 @@ describe Token, type: :model do
       end
     end
   end
-
-  describe "#activated?" do
-    context "when user is assigned" do
-      let(:user) { create(:user) }
-      let(:token) { build(:token, user:) }
-
-      it "returns true" do
-        expect(token.activated?).to be true
-      end
-    end
-
-    context "when user is not assigned" do
-      let(:token) { build(:token, user: nil) }
-
-      it "returns false" do
-        expect(token.activated?).to be false
-      end
-    end
-  end
 end

--- a/spec/app/services/telegram/message_dispatcher_spec.rb
+++ b/spec/app/services/telegram/message_dispatcher_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe Telegram::MessageDispatcher do
+  subject { described_class.call(command:, chat_id:, user_message:, name:) }
+
+  let(:chat_id) { 456 }
+  let(:name) { "Rihanna" }
+  let(:user_message) { { "text" => "ABC123" } }
+
+  describe ".call" do
+    context "when command is token" do
+      let(:command) { "token" }
+      let(:result) { double(failure?: false) }
+
+      it "calls TokenHandler::HandleToken with correct arguments" do
+        expect(TokenHandler::HandleToken)
+          .to receive(:call)
+          .with(chat_id:, token_code: "ABC123", name:)
+          .and_return(result)
+
+        subject
+      end
+
+      context "when interactor fails" do
+        let(:error_class) { TokenExpiredError }
+        let(:result) do
+          double(
+            failure?: true,
+            error: error_class
+          )
+        end
+
+        it "raises the error" do
+          allow(TokenHandler::HandleToken)
+            .to receive(:call)
+            .and_return(result)
+
+          expect { subject }.to raise_error(error_class)
+        end
+      end
+    end
+
+    context "when command is not token" do
+      let(:command) { "something_else" }
+      let(:result) { double(failure?: false) }
+
+      it "calls MessageHandler::HandleMessage" do
+        expect(MessageHandler::HandleMessage)
+          .to receive(:call)
+          .with(command:, user_message:)
+          .and_return(result)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/requests/telegram_webhooks_controller_spec.rb
+++ b/spec/requests/telegram_webhooks_controller_spec.rb
@@ -11,59 +11,58 @@ describe TelegramWebhooksController, telegram_bot: :rails do
     let(:token) { create(:token) }
 
     context "when token is correct" do
-      let(:expected_text) { "Hello, Rihanna!" }
+      let(:expected_greeting_text) do
+        "Hello, Rihanna!\n\n✅ Your token has been successfully activated!\n\n🎉 You have received 100 credits.\n"
+      end
 
-      it { should respond_with_message(expected_text) }
+      let(:expected_default_text) do
+        I18n.t(
+          "telegram_webhooks.commands.start.with_valid_token",
+          credits: 100
+        )
+      end
+
+      it { should respond_with_message(expected_greeting_text) }
+      it { should respond_with_message(expected_default_text) }
 
       context "and token greeting is nil" do
         let(:token) { create(:token, greeting: nil) }
 
-        let(:expected_text) { "Hi there! Please choose a command from the menu list." }
-
-        it { should respond_with_message(expected_text) }
+        it { should respond_with_message(expected_default_text) }
       end
-    end
-
-    context "when token is used" do
-      let(:token) { create(:token, :used) }
-
-      let(:expected_text) { "Sorry, the token you provided has already been used." }
-
-      it { should respond_with_message(expected_text) }
     end
 
     context "when token is invalid" do
-      subject { -> { dispatch_command(:start, "invalid_token") } }
-
-      let(:expected_text) { "Sorry, the token you provided is invalid. You can ask administrator for a valid token." }
-
-      it { should respond_with_message(expected_text) }
-    end
-
-    context "when token is missing" do
-      subject { -> { dispatch_command(:start) } }
-
-      let(:expected_text) { "Sorry, the token you provided is invalid. You can ask administrator for a valid token." }
-
-      it { should respond_with_message(expected_text) }
-    end
-
-    context "when token is expired" do
-      let(:token) { create(:token, :expired) }
-
-      let(:expected_text) { "Sorry, the token you provided has expired." }
-
-      it { should respond_with_message(expected_text) }
-    end
-
-    context "when user uses this token again" do
-      let(:user) { create(:user, chat_id: 456) }
-      let(:token) { create(:token, :used, user:) }
       let(:expected_text) do
-        "Hey, seems like you already have an active subscription :) Please choose a command and enjoy the bot!"
+        I18n.t(
+          "telegram_webhooks.commands.start.no_token",
+          credits: 100
+        )
       end
 
-      it { should respond_with_message(expected_text) }
+      context "when token is used" do
+        let(:token) { create(:token, :used) }
+
+        it { should respond_with_message(expected_text) }
+      end
+
+      context "when token is invalid" do
+        subject { -> { dispatch_command(:start, "invalid_token") } }
+
+        it { should respond_with_message(expected_text) }
+      end
+
+      context "when token is missing" do
+        subject { -> { dispatch_command(:start) } }
+
+        it { should respond_with_message(expected_text) }
+      end
+
+      context "when token is expired" do
+        let(:token) { create(:token, :expired) }
+
+        it { should respond_with_message(expected_text) }
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds ability to add token.
Also, it updates the /start logics:
If token is nil/invalid/expired/used -> just show default start message

So the logics is the following:
If user clicks on /start command:
  - no token provided
    - just show default start message
  - token provided
    - token is valid
      - show special greeting + default token activation message + default start message
    - token is invalid
      - show default start message

If user clicks on /token command
  - token invalid
    - show error message
  - token valid
    - show special greeting + default token activation message
    
![photo_2026-02-18_19-13-19 (2)](https://github.com/user-attachments/assets/3334dba3-24ce-47de-a285-42dc4ba7d8f7)
![photo_2026-02-18_19-13-19 (3)](https://github.com/user-attachments/assets/748c2871-5fed-4479-929b-dabf317b10d7)
![photo_2026-02-18_19-13-19 (4)](https://github.com/user-attachments/assets/117a20b2-8ae1-4a08-a877-5de59cda7cee)
![photo_2026-02-18_19-13-19](https://github.com/user-attachments/assets/95b4a912-85e6-4183-81c2-0cec8f27e433)

    
