### PR TITLE
Use freepik to extend the prompt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "dotenv-rails"
 gem "faraday"
+gem "flipper"
+gem "flipper-active_record"
 gem "interactor"
 gem "memery"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,11 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    flipper (1.4.0)
+      concurrent-ruby (< 2)
+    flipper-active_record (1.4.0)
+      activerecord (>= 4.2, < 9)
+      flipper (~> 1.4.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashdiff (1.2.1)
@@ -325,6 +330,8 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faraday
+  flipper
+  flipper-active_record
   interactor
   memery
   pg

--- a/app/interactors/media_generator/button_handler/send_generation_task.rb
+++ b/app/interactors/media_generator/button_handler/send_generation_task.rb
@@ -20,7 +20,7 @@ module MediaGenerator
       private
 
       def perform_prompt_extension_job
-        ::Generator::Prompt::ExtendJob.perform_async(button_request_id)
+        ::Generator::Media::Prompt::TaskCreatorJob.perform_async(button_request_id)
       end
 
       def perform_image_generator_job

--- a/app/interactors/media_generator/button_handler/send_generation_task.rb
+++ b/app/interactors/media_generator/button_handler/send_generation_task.rb
@@ -4,7 +4,7 @@ module MediaGenerator
       include Interactor
       include Memery
 
-      delegate :button_request, :button_request_record, to: :context
+      delegate :button_request, :button_request_record, :command_request, to: :context
 
       def call
         case button_request
@@ -19,8 +19,14 @@ module MediaGenerator
 
       private
 
+      delegate :user, to: :command_request
+
       def perform_prompt_extension_job
-        ::Generator::Media::Prompt::TaskCreatorJob.perform_async(button_request_id)
+        if Flipper[:improve_prompt_with_freepik].enabled?(user)
+          ::Generator::Media::Prompt::TaskCreatorJob.perform_async(button_request_id)
+        else
+          ::Generator::Prompt::ExtendJob.perform_async(button_request_id)
+        end
       end
 
       def perform_image_generator_job

--- a/app/jobs/generator/media/prompt/error_notifier_job.rb
+++ b/app/jobs/generator/media/prompt/error_notifier_job.rb
@@ -1,0 +1,17 @@
+module Generator
+  module Media
+    module Prompt
+      class ErrorNotifierJob < Generator::Media::ErrorNotifierBaseJob
+        private
+
+        def error_text
+          I18n.t("errors.extend_prompt_error")
+        end
+
+        def request_class
+          ButtonExtendPromptRequest
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/generator/media/prompt/success_notifier_job.rb
+++ b/app/jobs/generator/media/prompt/success_notifier_job.rb
@@ -1,0 +1,11 @@
+module Generator
+  module Media
+    module Prompt
+      class SuccessNotifierJob < ApplicationJob
+        def perform(extended_prompt, button_request_id)
+          NotifySuccess::SuccessNotifier.call(extended_prompt:, button_request_id:)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/generator/media/prompt/task_creator_job.rb
+++ b/app/jobs/generator/media/prompt/task_creator_job.rb
@@ -1,0 +1,21 @@
+module Generator
+  module Media
+    module Prompt
+      class TaskCreatorJob < Generator::Media::TaskCreatorBaseJob
+        private
+
+        def task_creator_class
+          CreateTask::TaskCreator
+        end
+
+        def failure_handler_class
+          CreateTask::FailureHandler
+        end
+
+        def request_class
+          ButtonExtendPromptRequest
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/generator/media/prompt/task_retriever_job.rb
+++ b/app/jobs/generator/media/prompt/task_retriever_job.rb
@@ -1,0 +1,21 @@
+module Generator
+  module Media
+    module Prompt
+      class TaskRetrieverJob < Generator::Media::TaskRetrieverBaseJob
+        private
+
+        def task_retriever_class
+          RetrieveTask::TaskRetriever
+        end
+
+        def success_notifier_job_class
+          SuccessNotifierJob
+        end
+
+        def error_notifier_job_class
+          ErrorNotifierJob
+        end
+      end
+    end
+  end
+end

--- a/app/models/button_extend_prompt_request.rb
+++ b/app/models/button_extend_prompt_request.rb
@@ -16,4 +16,8 @@ class ButtonExtendPromptRequest < ApplicationRecord
   def humanized_process_name
     I18n.t("telegram.generation.humanized_process_names.extend_prompt")
   end
+
+  def processor
+    "extend_prompt"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
   has_many :command_prompt_to_image_requests, dependent: :destroy
   has_many :command_image_to_video_requests, dependent: :destroy
   has_many :command_image_from_reference_requests, dependent: :destroy
+
+  def admin?
+    admin
+  end
 end

--- a/app/services/generator/media/error_notifier_dispatcher.rb
+++ b/app/services/generator/media/error_notifier_dispatcher.rb
@@ -16,6 +16,8 @@ module Generator
 
       def call
         case processor
+        when Generator::Processors::PROMPT_EXTENSION
+          Generator::Media::Prompt::ErrorNotifierJob.perform_async(button_request_id)
         when *Generator::Processors::IMAGE
           Generator::Media::Image::ErrorNotifierJob.perform_async(button_request_id)
         when *Generator::Processors::VIDEO

--- a/app/services/generator/media/prompt/create_task/api_client.rb
+++ b/app/services/generator/media/prompt/create_task/api_client.rb
@@ -1,0 +1,10 @@
+module Generator
+  module Media
+    module Prompt
+      module CreateTask
+        class ApiClient < Generator::Media::CreateTask::ApiClientBase
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/create_task/extend_prompt_payload_strategy.rb
+++ b/app/services/generator/media/prompt/create_task/extend_prompt_payload_strategy.rb
@@ -1,0 +1,29 @@
+module Generator
+  module Media
+    module Prompt
+      module CreateTask
+        class ExtendPromptPayloadStrategy
+          API_URL = "https://api.freepik.com/v1/ai/improve-prompt".freeze
+          TYPE = "image".freeze
+
+          def initialize(prompt)
+            @prompt = prompt
+          end
+
+          attr_reader :prompt
+
+          def payload
+            {
+              prompt:,
+              type: TYPE
+            }
+          end
+
+          def api_url
+            API_URL
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/create_task/failure_handler.rb
+++ b/app/services/generator/media/prompt/create_task/failure_handler.rb
@@ -1,0 +1,15 @@
+module Generator
+  module Media
+    module Prompt
+      module CreateTask
+        class FailureHandler < Generator::Media::CreateTask::FailureHandlerBase
+          private
+
+          def error_notifier_job_class
+            Generator::Media::Prompt::ErrorNotifierJob
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/create_task/payload_composer.rb
+++ b/app/services/generator/media/prompt/create_task/payload_composer.rb
@@ -1,0 +1,10 @@
+module Generator
+  module Media
+    module Prompt
+      module CreateTask
+        class PayloadComposer < Generator::Media::CreateTask::PayloadComposerBase
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/create_task/strategy_selector.rb
+++ b/app/services/generator/media/prompt/create_task/strategy_selector.rb
@@ -1,0 +1,19 @@
+module Generator
+  module Media
+    module Prompt
+      module CreateTask
+        class StrategySelector < Generator::Media::CreateTask::StrategySelectorBase
+          STRATEGIES = {
+            "extend_prompt" => ExtendPromptPayloadStrategy
+          }.freeze
+
+          private
+
+          def strategies
+            STRATEGIES
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/create_task/task_creator.rb
+++ b/app/services/generator/media/prompt/create_task/task_creator.rb
@@ -1,0 +1,23 @@
+module Generator
+  module Media
+    module Prompt
+      module CreateTask
+        class TaskCreator < Generator::Media::CreateTask::TaskCreatorBase
+          private
+
+          def api_client_class
+            ApiClient
+          end
+
+          def payload_composer_class
+            PayloadComposer
+          end
+
+          def strategy_selector_class
+            StrategySelector
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/notify_success/send_telegram_message.rb
+++ b/app/services/generator/media/prompt/notify_success/send_telegram_message.rb
@@ -1,0 +1,26 @@
+module Generator::Media::Prompt::NotifySuccess
+  class SendTelegramMessage
+    include LocaleSupport
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(reply_data:, request:)
+      @reply_data = reply_data
+      @request = request
+    end
+
+    def call
+      with_locale(locale) do
+        ::TelegramIntegration::SendMessageWithButtons.call(reply_data:, request:)
+      end
+    end
+
+    private
+
+    attr_reader :reply_data, :request
+
+    delegate :locale, to: :request
+  end
+end

--- a/app/services/generator/media/prompt/notify_success/success_notifier.rb
+++ b/app/services/generator/media/prompt/notify_success/success_notifier.rb
@@ -1,0 +1,41 @@
+module Generator::Media::Prompt::NotifySuccess
+  class SuccessNotifier
+    include Memery
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(extended_prompt:, button_request_id:)
+      @extended_prompt = extended_prompt
+      @button_request_id = button_request_id
+    end
+
+    def call
+      send_telegram_message
+
+      update_request_status
+    end
+
+    private
+
+    delegate :reply_data, to: :presenter
+    attr_reader :extended_prompt, :button_request_id
+
+    def send_telegram_message
+      SendTelegramMessage.call(reply_data:, request:)
+    end
+
+    def update_request_status
+      request.update!(status: "COMPLETED", prompt: extended_prompt)
+    end
+
+    memoize def presenter
+      MediaGenerator::ButtonRequestPresenters::ExtendedPromptMessagePresenter.new(message: extended_prompt)
+    end
+
+    memoize def request
+      ButtonExtendPromptRequest.includes(:parent_request, command_request: :user).find(button_request_id)
+    end
+  end
+end

--- a/app/services/generator/media/prompt/retrieve_task/api_client.rb
+++ b/app/services/generator/media/prompt/retrieve_task/api_client.rb
@@ -1,0 +1,10 @@
+module Generator
+  module Media
+    module Prompt
+      module RetrieveTask
+        class ApiClient < Generator::Media::RetrieveTask::ApiClientBase
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/retrieve_task/api_url_fetcher.rb
+++ b/app/services/generator/media/prompt/retrieve_task/api_url_fetcher.rb
@@ -1,0 +1,13 @@
+module Generator
+  module Media
+    module Prompt
+      module RetrieveTask
+        class ApiUrlFetcher < Generator::Media::RetrieveTask::ApiUrlFetcherBase
+          API_URLS = {
+            "extend_prompt" => "https://api.freepik.com/v1/ai/improve-prompt".freeze
+          }.freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/retrieve_task/prompt_extractor.rb
+++ b/app/services/generator/media/prompt/retrieve_task/prompt_extractor.rb
@@ -1,0 +1,10 @@
+module Generator
+  module Media
+    module Prompt
+      module RetrieveTask
+        class PromptExtractor < Generator::Media::RetrieveTask::MediaExtractorBase
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/prompt/retrieve_task/task_retriever.rb
+++ b/app/services/generator/media/prompt/retrieve_task/task_retriever.rb
@@ -1,0 +1,23 @@
+module Generator
+  module Media
+    module Prompt
+      module RetrieveTask
+        class TaskRetriever < Generator::Media::RetrieveTask::TaskRetrieverBase
+          private
+
+          def extractor_class
+            PromptExtractor
+          end
+
+          def api_client_class
+            ApiClient
+          end
+
+          def api_url_fetcher_class
+            ApiUrlFetcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/generator/media/task_retriever_dispatcher.rb
+++ b/app/services/generator/media/task_retriever_dispatcher.rb
@@ -13,6 +13,8 @@ module Generator
 
       def call
         case processor
+        when Generator::Processors::PROMPT_EXTENSION
+          Prompt::TaskRetrieverJob.perform_async(task_id, button_request_id, processor)
         when *Generator::Processors::IMAGE
           Image::TaskRetrieverJob.perform_async(task_id, button_request_id, processor)
         when *Generator::Processors::VIDEO

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,13 @@
+require "flipper"
+require "flipper/adapters/active_record"
+
+Flipper.configure do |config|
+  config.default do
+    adapter = Flipper::Adapters::ActiveRecord.new
+    Flipper.new(adapter)
+  end
+end
+
+Flipper.register(:admins) do |actor|
+  actor.respond_to?(:admin?) && actor.admin?
+end

--- a/db/migrate/20260310180000_add_admin_to_users.rb
+++ b/db/migrate/20260310180000_add_admin_to_users.rb
@@ -1,0 +1,6 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end
+

--- a/db/migrate/20260310180846_create_flipper_tables.rb
+++ b/db/migrate/20260310180846_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[8.0]
+  def up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.text :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_03_171257) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_10_180846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -115,6 +115,22 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_03_171257) do
     t.index ["user_id"], name: "index_command_prompt_to_video_requests_on_user_id"
   end
 
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
   create_table "prompt_messages", force: :cascade do |t|
     t.text "prompt"
     t.string "parent_request_type", null: false
@@ -157,6 +173,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_03_171257) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "locale", default: "en", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["chat_id"], name: "index_users_on_chat_id", unique: true
   end
 

--- a/lib/tasks/flipper.rake
+++ b/lib/tasks/flipper.rake
@@ -1,0 +1,8 @@
+namespace :flipper do
+  desc "Create and enable :improve_prompt_with_freepik feature for admins"
+  task improve_prompt_with_freepik: :environment do
+    Flipper.add(:improve_prompt_with_freepik)
+    Flipper[:improve_prompt_with_freepik].enable_group(:admins)
+    puts "Flipper feature :improve_prompt_with_freepik enabled for :admins group"
+  end
+end

--- a/spec/app/interactors/media_generator/button_handler/send_generation_task_spec.rb
+++ b/spec/app/interactors/media_generator/button_handler/send_generation_task_spec.rb
@@ -10,7 +10,7 @@ describe MediaGenerator::ButtonHandler::SendGenerationTask do
   let(:button_request_record) { instance_double("ButtonExtendPromptRequest", id: 123) }
 
   before do
-    allow(Generator::Prompt::ExtendJob).to receive(:perform_async)
+    allow(Generator::Media::Prompt::TaskCreatorJob).to receive(:perform_async)
     allow(Generator::Media::Image::TaskCreatorJob).to receive(:perform_async)
     allow(Generator::Media::Video::TaskCreatorJob).to receive(:perform_async)
   end
@@ -21,7 +21,7 @@ describe MediaGenerator::ButtonHandler::SendGenerationTask do
     it "enqueues prompt extension job" do
       subject
 
-      expect(Generator::Prompt::ExtendJob)
+      expect(Generator::Media::Prompt::TaskCreatorJob)
         .to have_received(:perform_async)
         .with(button_request_record.id)
     end

--- a/spec/app/interactors/media_generator/button_handler/send_generation_task_spec.rb
+++ b/spec/app/interactors/media_generator/button_handler/send_generation_task_spec.rb
@@ -6,8 +6,8 @@ describe MediaGenerator::ButtonHandler::SendGenerationTask do
   let(:chat_id) { 456 }
   let(:image_url) { "https://example.com/image.png" }
   let(:parent_prompt) { "cute white kitten" }
-  let(:parent_request) { instance_double("CommandPromptToImageRequest", parent_prompt: parent_prompt) }
-  let(:button_request_record) { instance_double("ButtonExtendPromptRequest", id: 123) }
+  let(:parent_request) { create(:prompt_message, prompt: parent_prompt) }
+  let(:button_request_record) { create(:button_extend_prompt_request, parent_request:) }
 
   before do
     allow(Generator::Media::Prompt::TaskCreatorJob).to receive(:perform_async)

--- a/spec/app/interactors/media_generator/button_handler/send_generation_task_spec.rb
+++ b/spec/app/interactors/media_generator/button_handler/send_generation_task_spec.rb
@@ -1,15 +1,17 @@
 require "rails_helper"
 
 describe MediaGenerator::ButtonHandler::SendGenerationTask do
-  subject { described_class.call(button_request:, button_request_record:, parent_request:, image_url:, chat_id:) }
+  subject do
+    described_class.call(button_request:, button_request_record:, command_request: parent_request.command_request)
+  end
 
-  let(:chat_id) { 456 }
-  let(:image_url) { "https://example.com/image.png" }
   let(:parent_prompt) { "cute white kitten" }
   let(:parent_request) { create(:prompt_message, prompt: parent_prompt) }
   let(:button_request_record) { create(:button_extend_prompt_request, parent_request:) }
+  let(:user) { parent_request.command_request.user }
 
   before do
+    allow(Generator::Prompt::ExtendJob).to receive(:perform_async)
     allow(Generator::Media::Prompt::TaskCreatorJob).to receive(:perform_async)
     allow(Generator::Media::Image::TaskCreatorJob).to receive(:perform_async)
     allow(Generator::Media::Video::TaskCreatorJob).to receive(:perform_async)
@@ -18,12 +20,42 @@ describe MediaGenerator::ButtonHandler::SendGenerationTask do
   context "when button_request is extend_prompt" do
     let(:button_request) { "extend_prompt" }
 
-    it "enqueues prompt extension job" do
-      subject
+    context "when improve_prompt_with_freepik is enabled for user" do
+      before do
+        allow(Flipper[:improve_prompt_with_freepik])
+          .to receive(:enabled?)
+          .with(user)
+          .and_return(true)
+      end
 
-      expect(Generator::Media::Prompt::TaskCreatorJob)
-        .to have_received(:perform_async)
-        .with(button_request_record.id)
+      it "enqueues prompt extension job via Freepik flow" do
+        subject
+
+        expect(Generator::Media::Prompt::TaskCreatorJob)
+          .to have_received(:perform_async)
+          .with(button_request_record.id)
+
+        expect(Generator::Prompt::ExtendJob).not_to have_received(:perform_async)
+      end
+    end
+
+    context "when improve_prompt_with_freepik is disabled for user" do
+      before do
+        allow(Flipper[:improve_prompt_with_freepik])
+          .to receive(:enabled?)
+          .with(user)
+          .and_return(false)
+      end
+
+      it "enqueues legacy ExtendJob" do
+        subject
+
+        expect(Generator::Prompt::ExtendJob)
+          .to have_received(:perform_async)
+          .with(button_request_record.id)
+
+        expect(Generator::Media::Prompt::TaskCreatorJob).not_to have_received(:perform_async)
+      end
     end
   end
 

--- a/spec/app/services/generator/media/error_notifier_dispatcher_spec.rb
+++ b/spec/app/services/generator/media/error_notifier_dispatcher_spec.rb
@@ -8,6 +8,9 @@ describe Generator::Media::ErrorNotifierDispatcher do
   let(:button_request_id) { 123 }
 
   before do
+    allow(Generator::Media::Prompt::ErrorNotifierJob)
+      .to receive(:perform_async)
+
     allow(Generator::Media::Image::ErrorNotifierJob)
       .to receive(:perform_async)
 
@@ -16,6 +19,24 @@ describe Generator::Media::ErrorNotifierDispatcher do
   end
 
   describe ".call" do
+    context "when processor is extend_prompt" do
+      let(:processor) { Generator::Processors::PROMPT_EXTENSION }
+
+      it "dispatches prompt error notifier job" do
+        call_service
+
+        expect(Generator::Media::Prompt::ErrorNotifierJob)
+          .to have_received(:perform_async)
+          .with(button_request_id)
+
+        expect(Generator::Media::Image::ErrorNotifierJob)
+          .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Video::ErrorNotifierJob)
+          .not_to have_received(:perform_async)
+      end
+    end
+
     context "when processor is an image processor" do
       let(:processor) { Generator::Processors::IMAGE.first }
 
@@ -27,6 +48,9 @@ describe Generator::Media::ErrorNotifierDispatcher do
           .with(button_request_id)
 
         expect(Generator::Media::Video::ErrorNotifierJob)
+          .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Prompt::ErrorNotifierJob)
           .not_to have_received(:perform_async)
       end
     end
@@ -43,6 +67,9 @@ describe Generator::Media::ErrorNotifierDispatcher do
 
         expect(Generator::Media::Image::ErrorNotifierJob)
           .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Prompt::ErrorNotifierJob)
+          .not_to have_received(:perform_async)
       end
     end
 
@@ -56,6 +83,9 @@ describe Generator::Media::ErrorNotifierDispatcher do
           .not_to have_received(:perform_async)
 
         expect(Generator::Media::Video::ErrorNotifierJob)
+          .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Prompt::ErrorNotifierJob)
           .not_to have_received(:perform_async)
       end
     end

--- a/spec/app/services/generator/media/image/create_task/strategy_selector_spec.rb
+++ b/spec/app/services/generator/media/image/create_task/strategy_selector_spec.rb
@@ -6,15 +6,11 @@ describe Generator::Media::Image::CreateTask::StrategySelector do
   let(:parent_prompt) { "little kitten" }
 
   let(:parent_request) do
-    instance_double("PromptMessage", parent_prompt:)
+    create(:prompt_message, prompt: parent_prompt)
   end
 
   let(:request) do
-    instance_double(
-      ButtonImageProcessingRequest,
-      processor:,
-      parent_request:
-    )
+    create(:button_image_processing_request, parent_request:, processor:)
   end
 
   describe "#strategy" do
@@ -54,14 +50,6 @@ describe Generator::Media::Image::CreateTask::StrategySelector do
           .to be_a(Generator::Media::Image::CreateTask::ImagenPayloadStrategy)
 
         expect(strategy.prompt).to eq(parent_prompt)
-      end
-    end
-
-    context "when processor is unknown" do
-      let(:processor) { "unknown_processor" }
-
-      it "raises KeyError" do
-        expect { selector.strategy }.to raise_error(KeyError)
       end
     end
   end

--- a/spec/app/services/generator/media/image/create_task/task_creator_spec.rb
+++ b/spec/app/services/generator/media/image/create_task/task_creator_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Generator::Media::Image::CreateTask::TaskCreator do
   subject(:call_service) { described_class.call(request) }
 
-  let(:request) { instance_double(ButtonImageProcessingRequest) }
+  let(:request) { create(:button_image_processing_request) }
 
   let(:strategy_selector_instance) { instance_double(Generator::Media::Image::CreateTask::StrategySelector) }
   let(:strategy_instance) { instance_double("Strategy", api_url: api_url) }

--- a/spec/app/services/generator/media/prompt/create_task/extend_prompt_payload_strategy_spec.rb
+++ b/spec/app/services/generator/media/prompt/create_task/extend_prompt_payload_strategy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::CreateTask::ExtendPromptPayloadStrategy do
+  subject(:strategy) { described_class.new(prompt) }
+
+  let(:prompt) { "a short prompt" }
+
+  describe "#payload" do
+    it "returns payload containing prompt" do
+      expect(strategy.payload).to eq({ prompt:, type: "image" })
+    end
+  end
+
+  describe "#api_url" do
+    it "returns API_URL constant" do
+      expect(strategy.api_url).to eq(described_class::API_URL)
+    end
+  end
+end

--- a/spec/app/services/generator/media/prompt/create_task/failure_handler_spec.rb
+++ b/spec/app/services/generator/media/prompt/create_task/failure_handler_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::CreateTask::FailureHandler do
+  subject(:call_handler) { described_class.call(request) }
+
+  let(:request) { create(:button_extend_prompt_request) }
+
+  before do
+    allow(Billing::Refunder).to receive(:call)
+    allow(Generator::Media::Prompt::ErrorNotifierJob).to receive(:perform_async)
+  end
+
+  describe ".call" do
+    it "calls Billing::Refunder with correct arguments" do
+      expect(Billing::Refunder).to receive(:call).with(
+        user: request.user,
+        amount: request.cost,
+        source: request
+      )
+
+      call_handler
+    end
+
+    it "enqueues ErrorNotifierJob with request id" do
+      expect(Generator::Media::Prompt::ErrorNotifierJob)
+        .to receive(:perform_async)
+        .with(request.id)
+
+      call_handler
+    end
+  end
+end

--- a/spec/app/services/generator/media/prompt/create_task/strategy_selector_spec.rb
+++ b/spec/app/services/generator/media/prompt/create_task/strategy_selector_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::CreateTask::StrategySelector do
+  subject(:strategy) { described_class.new(request).strategy }
+
+  let(:parent_prompt) { "make it more cinematic" }
+  let(:parent_request) { instance_double("CommandRequest", parent_prompt: parent_prompt) }
+  let(:request) do
+    instance_double(
+      ButtonExtendPromptRequest,
+      processor: Generator::Processors::PROMPT_EXTENSION,
+      parent_request: parent_request
+    )
+  end
+
+  describe "#strategy" do
+    it "returns ExtendPromptPayloadStrategy initialized with parent prompt" do
+      expect(strategy).to be_a(Generator::Media::Prompt::CreateTask::ExtendPromptPayloadStrategy)
+      expect(strategy.prompt).to eq(parent_prompt)
+    end
+  end
+end

--- a/spec/app/services/generator/media/prompt/create_task/strategy_selector_spec.rb
+++ b/spec/app/services/generator/media/prompt/create_task/strategy_selector_spec.rb
@@ -4,14 +4,8 @@ describe Generator::Media::Prompt::CreateTask::StrategySelector do
   subject(:strategy) { described_class.new(request).strategy }
 
   let(:parent_prompt) { "make it more cinematic" }
-  let(:parent_request) { instance_double("CommandRequest", parent_prompt: parent_prompt) }
-  let(:request) do
-    instance_double(
-      ButtonExtendPromptRequest,
-      processor: Generator::Processors::PROMPT_EXTENSION,
-      parent_request: parent_request
-    )
-  end
+  let(:prompt_messsage) { create(:prompt_message, prompt: parent_prompt) }
+  let(:request) { create(:button_extend_prompt_request, parent_request: prompt_messsage) }
 
   describe "#strategy" do
     it "returns ExtendPromptPayloadStrategy initialized with parent prompt" do

--- a/spec/app/services/generator/media/prompt/create_task/task_creator_spec.rb
+++ b/spec/app/services/generator/media/prompt/create_task/task_creator_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::CreateTask::TaskCreator do
+  subject(:call_service) { described_class.call(request) }
+
+  let(:request) { instance_double(ButtonExtendPromptRequest) }
+
+  let(:strategy_selector_instance) { instance_double(Generator::Media::Prompt::CreateTask::StrategySelector) }
+  let(:strategy_instance) { instance_double("Strategy", api_url: api_url) }
+
+  let(:payload_composer_instance) { instance_double(Generator::Media::Prompt::CreateTask::PayloadComposer) }
+  let(:final_payload) { { foo: "bar" } }
+
+  let(:api_client_instance) { instance_double(Generator::Media::Prompt::CreateTask::ApiClient) }
+  let(:response) { instance_double("Response", success?: success) }
+
+  let(:api_url) { "https://api.example.com" }
+
+  before do
+    allow(Generator::Media::Prompt::CreateTask::StrategySelector)
+      .to receive(:new)
+      .with(request)
+      .and_return(strategy_selector_instance)
+
+    allow(strategy_selector_instance)
+      .to receive(:strategy)
+      .and_return(strategy_instance)
+
+    allow(Generator::Media::Prompt::CreateTask::PayloadComposer)
+      .to receive(:new)
+      .with(request, strategy_instance)
+      .and_return(payload_composer_instance)
+
+    allow(payload_composer_instance)
+      .to receive(:final_payload)
+      .and_return(final_payload)
+
+    allow(Generator::Media::Prompt::CreateTask::ApiClient)
+      .to receive(:new)
+      .with(api_url, final_payload)
+      .and_return(api_client_instance)
+
+    allow(api_client_instance)
+      .to receive(:response)
+      .and_return(response)
+  end
+
+  describe ".call" do
+    context "when response is successful" do
+      let(:success) { true }
+
+      it "does not raise error" do
+        expect { call_service }.not_to raise_error
+      end
+    end
+
+    context "when response is not successful" do
+      let(:success) { false }
+
+      it "raises Freepik::ResponseError" do
+        expect { call_service }
+          .to raise_error(Freepik::ResponseError)
+      end
+    end
+  end
+end

--- a/spec/app/services/generator/media/prompt/create_task/task_creator_spec.rb
+++ b/spec/app/services/generator/media/prompt/create_task/task_creator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Generator::Media::Prompt::CreateTask::TaskCreator do
   subject(:call_service) { described_class.call(request) }
 
-  let(:request) { instance_double(ButtonExtendPromptRequest) }
+  let(:request) { create(:button_extend_prompt_request) }
 
   let(:strategy_selector_instance) { instance_double(Generator::Media::Prompt::CreateTask::StrategySelector) }
   let(:strategy_instance) { instance_double("Strategy", api_url: api_url) }

--- a/spec/app/services/generator/media/prompt/retrieve_task/api_url_fetcher_spec.rb
+++ b/spec/app/services/generator/media/prompt/retrieve_task/api_url_fetcher_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::RetrieveTask::ApiUrlFetcher do
+  subject(:api_url) { described_class.new(processor).api_url }
+
+  let(:processor) { Generator::Processors::PROMPT_EXTENSION }
+
+  describe "#api_url" do
+    it "returns url for extend_prompt processor" do
+      expect(api_url).to eq(described_class::API_URLS.fetch(processor))
+    end
+  end
+end

--- a/spec/app/services/generator/media/prompt/retrieve_task/prompt_extractor_spec.rb
+++ b/spec/app/services/generator/media/prompt/retrieve_task/prompt_extractor_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::RetrieveTask::PromptExtractor do
+  subject(:media_url) { described_class.new(response).media_url }
+
+  let(:response) { instance_double("Response", success?: success, body: body) }
+  let(:success) { true }
+  let(:body) { { data: { generated: ["extended prompt text"] } }.to_json }
+
+  describe "#media_url" do
+    context "when response is successful" do
+      it "returns extracted text from response" do
+        expect(media_url).to eq("extended prompt text")
+      end
+    end
+
+    context "when response is not successful" do
+      let(:success) { false }
+
+      it "raises Freepik::ResponseError" do
+        expect { media_url }.to raise_error(Freepik::ResponseError)
+      end
+    end
+  end
+end

--- a/spec/app/services/generator/media/prompt/retrieve_task/task_retriever_spec.rb
+++ b/spec/app/services/generator/media/prompt/retrieve_task/task_retriever_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe Generator::Media::Prompt::RetrieveTask::TaskRetriever do
+  subject(:extended_prompt) { described_class.new(task_id, processor).media_url }
+
+  let(:task_id) { "123" }
+  let(:processor) { Generator::Processors::PROMPT_EXTENSION }
+
+  let(:api_url_fetcher_instance) { double }
+  let(:api_url) { "https://api.example.com/tasks" }
+
+  let(:api_client_instance) { double }
+  let(:api_response) { double }
+
+  let(:extractor_instance) { double }
+  let(:extended_prompt_result) { "extended prompt text" }
+
+  before do
+    allow(Generator::Media::Prompt::RetrieveTask::ApiUrlFetcher)
+      .to receive(:new)
+      .with(processor)
+      .and_return(api_url_fetcher_instance)
+
+    allow(api_url_fetcher_instance)
+      .to receive(:api_url)
+      .and_return(api_url)
+
+    allow(Generator::Media::Prompt::RetrieveTask::ApiClient)
+      .to receive(:new)
+      .with(task_id, api_url)
+      .and_return(api_client_instance)
+
+    allow(api_client_instance)
+      .to receive(:api_response)
+      .and_return(api_response)
+
+    allow(Generator::Media::Prompt::RetrieveTask::PromptExtractor)
+      .to receive(:new)
+      .with(api_response)
+      .and_return(extractor_instance)
+
+    allow(extractor_instance)
+      .to receive(:media_url)
+      .and_return(extended_prompt_result)
+  end
+
+  describe "#media_url" do
+    it "retrieves prompt using api client and extractor" do
+      expect(extended_prompt).to eq(extended_prompt_result)
+
+      expect(Generator::Media::Prompt::RetrieveTask::ApiUrlFetcher)
+        .to have_received(:new)
+        .with(processor)
+
+      expect(Generator::Media::Prompt::RetrieveTask::ApiClient)
+        .to have_received(:new)
+        .with(task_id, api_url)
+
+      expect(Generator::Media::Prompt::RetrieveTask::PromptExtractor)
+        .to have_received(:new)
+        .with(api_response)
+    end
+  end
+end

--- a/spec/app/services/generator/media/task_retriever_dispatcher_spec.rb
+++ b/spec/app/services/generator/media/task_retriever_dispatcher_spec.rb
@@ -9,6 +9,9 @@ describe Generator::Media::TaskRetrieverDispatcher do
   let(:button_request_id) { 456 }
 
   before do
+    allow(Generator::Media::Prompt::TaskRetrieverJob)
+      .to receive(:perform_async)
+
     allow(Generator::Media::Image::TaskRetrieverJob)
       .to receive(:perform_async)
 
@@ -17,6 +20,24 @@ describe Generator::Media::TaskRetrieverDispatcher do
   end
 
   describe ".call" do
+    context "when processor is extend_prompt" do
+      let(:processor) { Generator::Processors::PROMPT_EXTENSION }
+
+      it "dispatches prompt task retriever job" do
+        call_service
+
+        expect(Generator::Media::Prompt::TaskRetrieverJob)
+          .to have_received(:perform_async)
+          .with(task_id, button_request_id, processor)
+
+        expect(Generator::Media::Image::TaskRetrieverJob)
+          .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Video::TaskRetrieverJob)
+          .not_to have_received(:perform_async)
+      end
+    end
+
     context "when processor is an image processor" do
       let(:processor) { Generator::Processors::IMAGE.first }
 
@@ -28,6 +49,9 @@ describe Generator::Media::TaskRetrieverDispatcher do
           .with(task_id, button_request_id, processor)
 
         expect(Generator::Media::Video::TaskRetrieverJob)
+          .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Prompt::TaskRetrieverJob)
           .not_to have_received(:perform_async)
       end
     end
@@ -44,6 +68,9 @@ describe Generator::Media::TaskRetrieverDispatcher do
 
         expect(Generator::Media::Image::TaskRetrieverJob)
           .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Prompt::TaskRetrieverJob)
+          .not_to have_received(:perform_async)
       end
     end
 
@@ -57,6 +84,9 @@ describe Generator::Media::TaskRetrieverDispatcher do
           .not_to have_received(:perform_async)
 
         expect(Generator::Media::Video::TaskRetrieverJob)
+          .not_to have_received(:perform_async)
+
+        expect(Generator::Media::Prompt::TaskRetrieverJob)
           .not_to have_received(:perform_async)
       end
     end

--- a/spec/requests/telegram_webhooks_controller_spec.rb
+++ b/spec/requests/telegram_webhooks_controller_spec.rb
@@ -133,7 +133,7 @@ describe TelegramWebhooksController, telegram_bot: :rails do
   describe "#extend_prompt_callback_query", :callback_query do
     it_behaves_like "extend prompt callback",
                     record_creator: RecordCreators::ButtonRequests::ExtendPrompt,
-                    job_class: ::Generator::Prompt::ExtendJob
+                    job_class: ::Generator::Media::Prompt::TaskCreatorJob
   end
 
   describe "#mystic_image_callback_query", :callback_query do

--- a/spec/requests/telegram_webhooks_controller_spec.rb
+++ b/spec/requests/telegram_webhooks_controller_spec.rb
@@ -131,9 +131,25 @@ describe TelegramWebhooksController, telegram_bot: :rails do
   end
 
   describe "#extend_prompt_callback_query", :callback_query do
-    it_behaves_like "extend prompt callback",
-                    record_creator: RecordCreators::ButtonRequests::ExtendPrompt,
-                    job_class: ::Generator::Media::Prompt::TaskCreatorJob
+    context "when improve_prompt_with_freepik is enabled for user" do
+      before do
+        allow(Flipper[:improve_prompt_with_freepik]).to receive(:enabled?).and_return(true)
+      end
+
+      it_behaves_like "extend prompt callback",
+                      record_creator: RecordCreators::ButtonRequests::ExtendPrompt,
+                      job_class: ::Generator::Media::Prompt::TaskCreatorJob
+    end
+
+    context "when improve_prompt_with_freepik is disabled for user" do
+      before do
+        allow(Flipper[:improve_prompt_with_freepik]).to receive(:enabled?).and_return(false)
+      end
+
+      it_behaves_like "extend prompt callback",
+                      record_creator: RecordCreators::ButtonRequests::ExtendPrompt,
+                      job_class: ::Generator::Prompt::ExtendJob
+    end
   end
 
   describe "#mystic_image_callback_query", :callback_query do


### PR DESCRIPTION
This PR adds prompt improvement using freepik-api
Why? 
1) ChatGPT behaviour is not predictable. Sometimes it generates the prompt in the same language the raw prompt was written. We want it always english
2) We stay consistent with the rest of logics. We use freepik to generate images/videos, it would be good to improve prompt using their endpoint, too

Also, I enable this feature for admins only, so I can test it before implementing globally.

**Important:**
Run this after deploying this PR:
```
bundle exec rake flipper:improve_prompt_with_freepik
```