### PR TITLE
Add regenerate button

### DIFF
--- a/app/models/button_video_processing_request.rb
+++ b/app/models/button_video_processing_request.rb
@@ -1,5 +1,6 @@
 class ButtonVideoProcessingRequest < ApplicationRecord
   include HasOriginPrompt
+  include HasOriginImage
 
   PROCESSOR_TYPES = %w[
     kling_2_1_pro_image_to_video
@@ -23,5 +24,9 @@ class ButtonVideoProcessingRequest < ApplicationRecord
 
   def humanized_process_name
     I18n.t("telegram.generation.humanized_process_names.video.#{processor}", locale:)
+  end
+
+  def resolved_image_url
+    origin_image_url
   end
 end

--- a/app/models/concerns/has_origin_image.rb
+++ b/app/models/concerns/has_origin_image.rb
@@ -1,0 +1,31 @@
+module HasOriginImage
+  extend ActiveSupport::Concern
+
+  def origin_image_url
+    each_parent_request do |req|
+      return req.resolved_image_url if image_present?(req)
+    end
+
+    nil
+  end
+
+  private
+
+  def each_parent_request
+    req = parent_request_of(self)
+
+    while req
+      yield req
+
+      req = parent_request_of(req)
+    end
+  end
+
+  def parent_request_of(req)
+    req.respond_to?(:parent_request) ? req.parent_request : nil
+  end
+
+  def image_present?(req)
+    req.respond_to?(:resolved_image_url) && req.resolved_image_url.present?
+  end
+end

--- a/app/presenters/media_generator/button_request_presenters/image_processed_message/context.rb
+++ b/app/presenters/media_generator/button_request_presenters/image_processed_message/context.rb
@@ -7,6 +7,7 @@ module MediaGenerator
         :locale,
         :balance,
         :processor_name,
+        :processor,
         keyword_init: true
       )
     end

--- a/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_image.rb
+++ b/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_image.rb
@@ -3,10 +3,11 @@ module MediaGenerator
     module ImageProcessedMessage
       class ForPromptToImage < BasePresenter
         include MessageInterface
-        def initialize(balance:, processor_name:, **kwargs)
+        def initialize(balance:, processor_name:, processor:, **kwargs)
           super(**kwargs)
           @balance = balance
           @processor_name = processor_name
+          @processor = processor
         end
 
         def formatted_text
@@ -21,12 +22,12 @@ module MediaGenerator
         end
 
         def inline_keyboard
-          Buttons::ForImageMessage::ForPromptToImage.build(locale:)
+          Buttons::ForImageMessage::ForPromptToImage.build(locale:, processor:)
         end
 
         private
 
-        attr_reader :balance, :processor_name
+        attr_reader :balance, :processor_name, :processor
       end
     end
   end

--- a/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_video.rb
+++ b/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_video.rb
@@ -3,10 +3,11 @@ module MediaGenerator
     module ImageProcessedMessage
       class ForPromptToVideo < BasePresenter
         include MessageInterface
-        def initialize(balance:, processor_name:, **kwargs)
+        def initialize(balance:, processor_name:, processor:, **kwargs)
           super(**kwargs)
           @balance = balance
           @processor_name = processor_name
+          @processor = processor
         end
 
         def formatted_text
@@ -23,12 +24,12 @@ module MediaGenerator
         end
 
         def inline_keyboard
-          Buttons::ForImageMessage::ForPromptToVideo.build(locale:)
+          Buttons::ForImageMessage::ForPromptToVideo.build(locale:, processor:)
         end
 
         private
 
-        attr_reader :balance, :processor_name
+        attr_reader :balance, :processor_name, :processor
       end
     end
   end

--- a/app/presenters/media_generator/button_request_presenters/image_processed_message/presenter_selector.rb
+++ b/app/presenters/media_generator/button_request_presenters/image_processed_message/presenter_selector.rb
@@ -13,14 +13,15 @@ module MediaGenerator
 
         attr_reader :context
 
-        delegate :image_url, :command_request_classname, :locale, :balance, :processor_name, to: :context
+        delegate :image_url, :command_request_classname, :locale, :balance, :processor_name, :processor, to: :context
 
         def presenter
           PRESENTERS[command_request_classname].new(
             message: image_url,
             locale:,
             balance:,
-            processor_name:
+            processor_name:,
+            processor:
           )
         end
       end

--- a/app/presenters/media_generator/button_request_presenters/video_processed_message_presenter.rb
+++ b/app/presenters/media_generator/button_request_presenters/video_processed_message_presenter.rb
@@ -2,10 +2,11 @@ module MediaGenerator
   module ButtonRequestPresenters
     class VideoProcessedMessagePresenter < BasePresenter
       include MessageInterface
-      def initialize(balance:, processor_name:, **kwargs)
+      def initialize(balance:, processor_name:, processor:, **kwargs)
         super(**kwargs)
         @balance = balance
         @processor_name = processor_name
+        @processor = processor
       end
 
       def formatted_text
@@ -20,12 +21,12 @@ module MediaGenerator
       end
 
       def inline_keyboard
-        Buttons::ForVideoMessage.build(locale:)
+        Buttons::ForVideoMessage.build(locale:, processor:)
       end
 
       private
 
-      attr_reader :balance, :processor_name
+      attr_reader :balance, :processor_name, :processor
     end
   end
 end

--- a/app/services/generator/media/image/notify_success/presenter_factory.rb
+++ b/app/services/generator/media/image/notify_success/presenter_factory.rb
@@ -12,7 +12,7 @@ module Generator::Media::Image::NotifySuccess
 
     attr_reader :image_url, :request, :balance
 
-    delegate :locale, :humanized_process_name, to: :request
+    delegate :locale, :humanized_process_name, :processor, to: :request
 
     def presenter_selector
       MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::PresenterSelector.new(
@@ -26,7 +26,8 @@ module Generator::Media::Image::NotifySuccess
         command_request_classname:,
         locale:,
         balance:,
-        processor_name: humanized_process_name
+        processor_name: humanized_process_name,
+        processor:
       )
     end
 

--- a/app/services/generator/media/video/notify_success/send_telegram_message.rb
+++ b/app/services/generator/media/video/notify_success/send_telegram_message.rb
@@ -13,7 +13,10 @@ module Generator::Media::Video::NotifySuccess
 
     def call
       with_locale(locale) do
-        ::Telegram.bot.send_message(chat_id:, **reply_data_with_reply_reference)
+        ::TelegramIntegration::SendMessageWithButtons.call(
+          reply_data: reply_data_with_reply_reference,
+          request:
+        )
       end
     end
 
@@ -21,7 +24,7 @@ module Generator::Media::Video::NotifySuccess
 
     attr_reader :reply_data, :request
 
-    delegate :locale, :chat_id, :parent_request, to: :request
+    delegate :locale, :parent_request, to: :request
     delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
     delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
 

--- a/app/services/generator/media/video/notify_success/success_notifier.rb
+++ b/app/services/generator/media/video/notify_success/success_notifier.rb
@@ -23,7 +23,7 @@ module Generator::Media::Video::NotifySuccess
     delegate :user, to: :request
     delegate :balance, to: :user
     delegate :credits, to: :balance, prefix: true
-    delegate :locale, :humanized_process_name, to: :request
+    delegate :locale, :humanized_process_name, :processor, to: :request
     attr_reader :video_url, :button_request_id
 
     def send_telegram_message
@@ -39,7 +39,8 @@ module Generator::Media::Video::NotifySuccess
         message: video_url,
         balance: balance_credits,
         locale:,
-        processor_name: humanized_process_name
+        processor_name: humanized_process_name,
+        processor:
       )
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,9 @@ en:
           wan_2_2_image_to_video:
             one: "Wan 2.2 (%{count} credit)"
             other: "Wan 2.2 (%{count} credits)"
+        regenerate:
+          one: "Regenerate (%{count} credit)"
+          other: "Regenerate (%{count} credits)"
         set_locale:
           en: "English"
           ru: "Русский"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -136,6 +136,9 @@ es:
           wan_2_2_image_to_video:
             one: "Wan 2.2 (%{count} crédito)"
             other: "Wan 2.2 (%{count} créditos)"
+        regenerate:
+          one: "Regenerar (%{count} crédito)"
+          other: "Regenerar (%{count} créditos)"
         set_locale:
           en: "English"
           ru: "Русский"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -153,6 +153,11 @@ ru:
             few: "Wan 2.2 (%{count} кредита)"
             many: "Wan 2.2 (%{count} кредитов)"
             other: "Wan 2.2 (%{count} кредитов)"
+        regenerate:
+          one: "Сгенерировать снова (%{count} кредит)"
+          few: "Сгенерировать снова (%{count} кредита)"
+          many: "Сгенерировать снова (%{count} кредитов)"
+          other: "Сгенерировать снова (%{count} кредитов)"
         set_locale:
           en: "English"
           ru: "Русский"

--- a/lib/buttons/base.rb
+++ b/lib/buttons/base.rb
@@ -25,6 +25,17 @@ module Buttons
       }
     end
 
+    def regenerate_button_for(scope, processor)
+      {
+        text: I18n.t(
+          "telegram_webhooks.message.buttons.regenerate",
+          count: cost_for(scope, processor),
+          locale:
+        ),
+        callback_data: processor.to_s
+      }
+    end
+
     def cost_for(scope, type)
       COSTS[scope.to_sym][type.to_sym]
     end

--- a/lib/buttons/for_image_message/for_prompt_to_image.rb
+++ b/lib/buttons/for_image_message/for_prompt_to_image.rb
@@ -1,21 +1,22 @@
 module Buttons
   module ForImageMessage
-    class ForPromptToImage
-      def self.build(...)
-        new(...).build
-      end
-
-      def initialize(locale: I18n.locale)
-        @locale = locale
+    class ForPromptToImage < Buttons::Base
+      def initialize(processor:, **kwargs)
+        super(**kwargs)
+        @processor = processor
       end
 
       def build
-        []
+        [[regenerate_button]]
       end
 
       private
 
-      attr_reader :locale
+      attr_reader :processor
+
+      def regenerate_button
+        regenerate_button_for(:generate_image, processor)
+      end
     end
   end
 end

--- a/lib/buttons/for_image_message/for_prompt_to_video.rb
+++ b/lib/buttons/for_image_message/for_prompt_to_video.rb
@@ -1,11 +1,26 @@
 module Buttons
   module ForImageMessage
     class ForPromptToVideo < Buttons::Base
+      def initialize(processor:, **kwargs)
+        super(**kwargs)
+        @processor = processor
+      end
+
       def build
-        processor_rows
+        [regenerate_row, *processor_rows]
       end
 
       private
+
+      attr_reader :processor
+
+      def regenerate_row
+        [regenerate_button]
+      end
+
+      def regenerate_button
+        regenerate_button_for(:generate_image, processor)
+      end
 
       def processor_rows
         media_processors.map { |processor| [button_for(:generate_video, processor)] }

--- a/lib/buttons/for_video_message.rb
+++ b/lib/buttons/for_video_message.rb
@@ -1,19 +1,20 @@
 module Buttons
-  class ForVideoMessage
-    def self.build(...)
-      new(...).build
-    end
-
-    def initialize(locale: I18n.locale)
-      @locale = locale
+  class ForVideoMessage < Buttons::Base
+    def initialize(processor:, **kwargs)
+      super(**kwargs)
+      @processor = processor
     end
 
     def build
-      []
+      [[regenerate_button]]
     end
 
     private
 
-    attr_reader :locale
+    attr_reader :processor
+
+    def regenerate_button
+      regenerate_button_for(:generate_video, processor)
+    end
   end
 end

--- a/spec/app/models/button_video_processing_request_spec.rb
+++ b/spec/app/models/button_video_processing_request_spec.rb
@@ -72,4 +72,17 @@ describe ButtonVideoProcessingRequest, type: :model do
       end
     end
   end
+
+  describe "#resolved_image_url" do
+    context "when parent has resolved image url" do
+      let(:image_parent_request) do
+        create(:button_image_processing_request, image_url: "https://example.com/source-image.jpg")
+      end
+      let(:record) { create(:button_video_processing_request, parent_request: image_parent_request) }
+
+      it "returns origin image url from lineage" do
+        expect(record.resolved_image_url).to eq("https://example.com/source-image.jpg")
+      end
+    end
+  end
 end

--- a/spec/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_image_spec.rb
+++ b/spec/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_image_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::ForPromptToImage do
-  subject { described_class.new(message:, balance:, processor_name:) }
+  subject { described_class.new(message:, balance:, processor_name:, processor:) }
 
   let(:message) { "https://example.com/image.png" }
   let(:balance) { 8 }
   let(:processor_name) { "Mystic image" }
+  let(:processor) { "mystic_image" }
 
   describe "#formatted_text" do
     it "returns an HTML link to the image" do
@@ -26,6 +27,10 @@ describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::ForProm
   describe "#inline_keyboard" do
     subject { super().inline_keyboard }
 
-    it { is_expected.to eq([]) }
+    it do
+      is_expected.to eq(
+        [[{ callback_data: "mystic_image", text: "Regenerate (2 credits)" }]]
+      )
+    end
   end
 end

--- a/spec/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_video_spec.rb
+++ b/spec/app/presenters/media_generator/button_request_presenters/image_processed_message/for_prompt_to_video_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::ForPromptToVideo do
-  subject { described_class.new(message:, balance:, processor_name:) }
+  subject { described_class.new(message:, balance:, processor_name:, processor:) }
 
   let(:message) { "https://example.com/image.png" }
   let(:balance) { 4 }
   let(:processor_name) { "Mystic image" }
+  let(:processor) { "mystic_image" }
 
   describe "#formatted_text" do
     it "returns an HTML link to the image" do
@@ -30,6 +31,8 @@ describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::ForProm
 
     let(:expected_buttons) do
       [
+        [{ callback_data: "mystic_image",
+           text: "Regenerate (2 credits)" }],
         [{ callback_data: "kling_2_1_pro_image_to_video",
            text: "Kling Pro 2.1 (10 credits)" }],
         [{ callback_data: "seedance_1_5_pro_image_to_video",

--- a/spec/app/presenters/media_generator/button_request_presenters/image_processed_message/presenter_selector_spec.rb
+++ b/spec/app/presenters/media_generator/button_request_presenters/image_processed_message/presenter_selector_spec.rb
@@ -6,13 +6,15 @@ describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::Present
     let(:locale) { :ru }
     let(:balance) { 4 }
     let(:processor_name) { "Mystic image" }
+    let(:processor) { "mystic_image" }
     let(:context) do
       MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::Context.new(
         image_url:,
         command_request_classname:,
         locale:,
         balance:,
-        processor_name:
+        processor_name:,
+        processor:
       )
     end
 
@@ -28,7 +30,7 @@ describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::Present
       before do
         allow(MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::ForPromptToImage)
           .to receive(:new)
-          .with(message: image_url, locale:, balance:, processor_name:)
+          .with(message: image_url, locale:, balance:, processor_name:, processor:)
           .and_return(presenter_instance)
       end
 
@@ -49,7 +51,7 @@ describe MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::Present
       before do
         allow(MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::ForPromptToVideo)
           .to receive(:new)
-          .with(message: image_url, locale:, balance:, processor_name:)
+          .with(message: image_url, locale:, balance:, processor_name:, processor:)
           .and_return(presenter_instance)
       end
 

--- a/spec/app/presenters/media_generator/button_request_presenters/video_processed_message_presenter_spec.rb
+++ b/spec/app/presenters/media_generator/button_request_presenters/video_processed_message_presenter_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 describe MediaGenerator::ButtonRequestPresenters::VideoProcessedMessagePresenter do
-  subject { described_class.new(message:, balance:, processor_name:) }
+  subject { described_class.new(message:, balance:, processor_name:, processor:) }
 
   let(:message) { "https://example.com/video.mp4" }
   let(:balance) { 12 }
   let(:processor_name) { "Kling Pro video" }
+  let(:processor) { "kling_2_1_pro_image_to_video" }
 
   describe "#formatted_text" do
     it "returns an HTML link to the video" do
@@ -26,6 +27,10 @@ describe MediaGenerator::ButtonRequestPresenters::VideoProcessedMessagePresenter
   describe "#inline_keyboard" do
     subject { super().inline_keyboard }
 
-    it { is_expected.to eq([]) }
+    it do
+      is_expected.to eq(
+        [[{ callback_data: "kling_2_1_pro_image_to_video", text: "Regenerate (10 credits)" }]]
+      )
+    end
   end
 end

--- a/spec/app/services/generator/media/image/notify_success/presenter_factory_spec.rb
+++ b/spec/app/services/generator/media/image/notify_success/presenter_factory_spec.rb
@@ -10,6 +10,7 @@ describe Generator::Media::Image::NotifySuccess::PresenterFactory do
   let(:image_url) { "http://example.com/image.png" }
   let(:balance) { 5 }
   let(:processor_name) { request.humanized_process_name }
+  let(:processor) { request.processor }
   let(:context_class) { MediaGenerator::ButtonRequestPresenters::ImageProcessedMessage::Context }
 
   let(:command_request) { create(:command_prompt_to_image_request) }
@@ -43,7 +44,8 @@ describe Generator::Media::Image::NotifySuccess::PresenterFactory do
             command_request_classname: "CommandPromptToImageRequest",
             locale: "en",
             balance:,
-            processor_name:
+            processor_name:,
+            processor:
           )
         )
     end

--- a/spec/app/services/generator/media/video/notify_success/send_telegram_message_spec.rb
+++ b/spec/app/services/generator/media/video/notify_success/send_telegram_message_spec.rb
@@ -11,13 +11,9 @@ describe Generator::Media::Video::NotifySuccess::SendTelegramMessage do
     create(:button_video_processing_request)
   end
 
-  let(:telegram_bot) { double }
-
   before do
-    allow(::Telegram).to receive(:bot).and_return(telegram_bot)
-
-    allow(telegram_bot)
-      .to receive(:send_message)
+    allow(TelegramIntegration::SendMessageWithButtons)
+      .to receive(:call)
   end
 
   describe ".call" do
@@ -29,9 +25,12 @@ describe Generator::Media::Video::NotifySuccess::SendTelegramMessage do
       it "sends telegram message as reply" do
         call_service
 
-        expect(telegram_bot)
-          .to have_received(:send_message)
-          .with(chat_id: request.chat_id, **reply_data.merge(reply_to_message_id: 123_456))
+        expect(TelegramIntegration::SendMessageWithButtons)
+          .to have_received(:call)
+          .with(
+            reply_data: reply_data.merge(reply_to_message_id: 123_456),
+            request:
+          )
       end
     end
 
@@ -39,9 +38,12 @@ describe Generator::Media::Video::NotifySuccess::SendTelegramMessage do
       it "sends telegram message without reply reference" do
         call_service
 
-        expect(telegram_bot)
-          .to have_received(:send_message)
-          .with(chat_id: request.chat_id, **reply_data)
+        expect(TelegramIntegration::SendMessageWithButtons)
+          .to have_received(:call)
+          .with(
+            reply_data:,
+            request:
+          )
       end
     end
 
@@ -53,9 +55,12 @@ describe Generator::Media::Video::NotifySuccess::SendTelegramMessage do
       it "sends telegram message without reply reference" do
         call_service
 
-        expect(telegram_bot)
-          .to have_received(:send_message)
-          .with(chat_id: request.chat_id, **reply_data)
+        expect(TelegramIntegration::SendMessageWithButtons)
+          .to have_received(:call)
+          .with(
+            reply_data:,
+            request:
+          )
       end
     end
   end

--- a/spec/app/services/generator/media/video/notify_success/success_notifier_spec.rb
+++ b/spec/app/services/generator/media/video/notify_success/success_notifier_spec.rb
@@ -9,6 +9,7 @@ describe Generator::Media::Video::NotifySuccess::SuccessNotifier do
   let(:balance) { 11 }
   let(:user) { create(:user, :with_custom_balance, credits: balance) }
   let(:processor_name) { button_request.humanized_process_name }
+  let(:processor) { button_request.processor }
   let(:locale) { user.locale }
 
   let(:button_request) do
@@ -21,7 +22,7 @@ describe Generator::Media::Video::NotifySuccess::SuccessNotifier do
   before do
     allow(MediaGenerator::ButtonRequestPresenters::VideoProcessedMessagePresenter)
       .to receive(:new)
-      .with(message: video_url, balance: balance, locale:, processor_name:)
+      .with(message: video_url, balance: balance, locale:, processor_name:, processor:)
       .and_return(presenter_instance)
 
     allow(presenter_instance)
@@ -38,7 +39,7 @@ describe Generator::Media::Video::NotifySuccess::SuccessNotifier do
 
       expect(MediaGenerator::ButtonRequestPresenters::VideoProcessedMessagePresenter)
         .to have_received(:new)
-        .with(message: video_url, balance: balance, locale:, processor_name:)
+        .with(message: video_url, balance: balance, locale:, processor_name:, processor:)
 
       expect(Generator::Media::Video::NotifySuccess::SendTelegramMessage)
         .to have_received(:call)

--- a/spec/lib/buttons/for_image_message/for_prompt_to_image_spec.rb
+++ b/spec/lib/buttons/for_image_message/for_prompt_to_image_spec.rb
@@ -2,14 +2,24 @@ require "rails_helper"
 
 describe Buttons::ForImageMessage::ForPromptToImage do
   describe ".build" do
-    subject(:result) { described_class.build }
+    subject(:result) { described_class.build(processor:) }
 
-    it "returns an empty array" do
-      expect(result).to eq([])
+    let(:processor) { "mystic_image" }
+
+    it "returns regenerate button row" do
+      expect(result).to eq(
+        [[{ callback_data: "mystic_image", text: "Regenerate (2 credits)" }]]
+      )
     end
 
-    it "returns an Array" do
-      expect(result).to be_an(Array)
+    context "when locale is russian" do
+      subject(:result) { described_class.build(processor:, locale: :ru) }
+
+      it "returns regenerate button row with russian pluralization" do
+        expect(result).to eq(
+          [[{ callback_data: "mystic_image", text: "Сгенерировать снова (2 кредита)" }]]
+        )
+      end
     end
   end
 end

--- a/spec/lib/buttons/for_image_message/for_prompt_to_video_spec.rb
+++ b/spec/lib/buttons/for_image_message/for_prompt_to_video_spec.rb
@@ -1,11 +1,15 @@
 require "rails_helper"
 
 describe Buttons::ForImageMessage::ForPromptToVideo do
-  subject(:result) { described_class.build }
+  subject(:result) { described_class.build(processor:) }
+
+  let(:processor) { "mystic_image" }
 
   it "builds processor buttons as separate rows" do
     expect(result).to eq(
       [
+        [{ callback_data: "mystic_image",
+           text: "Regenerate (2 credits)" }],
         [{ callback_data: "kling_2_1_pro_image_to_video",
            text: "Kling Pro 2.1 (10 credits)" }],
         [{ callback_data: "seedance_1_5_pro_image_to_video",
@@ -17,11 +21,13 @@ describe Buttons::ForImageMessage::ForPromptToVideo do
   end
 
   context "when locale is russian" do
-    subject(:result) { described_class.build(locale: :ru) }
+    subject(:result) { described_class.build(processor:, locale: :ru) }
 
     it "builds processor buttons with russian pluralization" do
       expect(result).to eq(
         [
+          [{ callback_data: "mystic_image",
+             text: "Сгенерировать снова (2 кредита)" }],
           [{ callback_data: "kling_2_1_pro_image_to_video",
              text: "Kling Pro 2.1 (10 кредитов)" }],
           [{ callback_data: "seedance_1_5_pro_image_to_video",

--- a/spec/lib/buttons/for_video_message_spec.rb
+++ b/spec/lib/buttons/for_video_message_spec.rb
@@ -2,14 +2,24 @@ require "rails_helper"
 
 describe Buttons::ForVideoMessage do
   describe ".build" do
-    subject(:result) { described_class.build }
+    subject(:result) { described_class.build(processor:) }
 
-    it "returns an empty array" do
-      expect(result).to eq([])
+    let(:processor) { "kling_2_1_pro_image_to_video" }
+
+    it "returns regenerate button row" do
+      expect(result).to eq(
+        [[{ callback_data: "kling_2_1_pro_image_to_video", text: "Regenerate (10 credits)" }]]
+      )
     end
 
-    it "returns an Array" do
-      expect(result).to be_an(Array)
+    context "when locale is russian" do
+      subject(:result) { described_class.build(processor:, locale: :ru) }
+
+      it "returns regenerate button row with russian pluralization" do
+        expect(result).to eq(
+          [[{ callback_data: "kling_2_1_pro_image_to_video", text: "Сгенерировать снова (10 кредитов)" }]]
+        )
+      end
     end
   end
 end

--- a/spec/lib/record_creators/button_requests/videos/image_resolver_spec.rb
+++ b/spec/lib/record_creators/button_requests/videos/image_resolver_spec.rb
@@ -19,5 +19,16 @@ describe RecordCreators::ButtonRequests::Videos::ImageResolver do
         expect(resolver.image_url).to be_nil
       end
     end
+
+    context "when parent request is video processing request" do
+      let(:image_parent_request) do
+        create(:button_image_processing_request, image_url: "https://example.com/source-image.jpg")
+      end
+      let(:parent_request) { create(:button_video_processing_request, parent_request: image_parent_request) }
+
+      it "returns resolved image url from parent of video request" do
+        expect(resolver.image_url).to eq("https://example.com/source-image.jpg")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds "Regenerate" button

Every time you get a media content (image or video) you are able to regenerate it. The same request with the same parameters will be sent to Freepik.