### PR TITLE
Add telegram answer callback for media generation

### DIFF
--- a/app/interactors/media_generator/button_handler/acknowledge_callback_query.rb
+++ b/app/interactors/media_generator/button_handler/acknowledge_callback_query.rb
@@ -1,0 +1,45 @@
+module MediaGenerator
+  module ButtonHandler
+    class AcknowledgeCallbackQuery
+      include Interactor
+
+      delegate :callback_query_id, :button_request, :command_request, to: :context
+      delegate :user, to: :command_request
+      delegate :locale, to: :user
+
+      def call
+        return if callback_query_id.blank?
+
+        TelegramIntegration::SendAnswerCallbackQuery.call(
+          callback_query_id:,
+          process_name: processing_toast_name
+        )
+      end
+
+      private
+
+      def processing_toast_name
+        case button_request
+        when ButtonActions::GENERATE_CARTOON_VIDEO
+          cartoon_video_process_name
+        when ButtonActions::GENERATE_CARTOON_AUDIO
+          cartoon_audio_process_name
+        end
+      end
+
+      def cartoon_video_process_name
+        I18n.t(
+          "telegram.generation.humanized_process_names.video.#{CreateCartoonVideoRequest::PROCESSOR}",
+          locale:
+        )
+      end
+
+      def cartoon_audio_process_name
+        I18n.t(
+          "telegram.generation.humanized_process_names.audio.voices.#{CreateCartoonAudioRequest::VOICE}",
+          locale:
+        )
+      end
+    end
+  end
+end

--- a/app/interactors/media_generator/button_handler/handle_generate_cartoon_audio_button.rb
+++ b/app/interactors/media_generator/button_handler/handle_generate_cartoon_audio_button.rb
@@ -4,7 +4,7 @@ module MediaGenerator
       include Interactor::Organizer
 
       organize FindParentRequest, FindCommandRequest, ValidateCartoonVideoScriptRequest,
-               CreateCartoonAudioRequest, DecrementBalance, NotifyProcessingStarted,
+               AcknowledgeCallbackQuery, CreateCartoonAudioRequest, DecrementBalance,
                SendGenerationTask
     end
   end

--- a/app/interactors/media_generator/button_handler/handle_generate_cartoon_video_button.rb
+++ b/app/interactors/media_generator/button_handler/handle_generate_cartoon_video_button.rb
@@ -4,7 +4,7 @@ module MediaGenerator
       include Interactor::Organizer
 
       organize FindParentRequest, FindCommandRequest, ValidateCartoonScriptRequest,
-               CreateCartoonVideoRequest, DecrementBalance, NotifyProcessingStarted,
+               AcknowledgeCallbackQuery, CreateCartoonVideoRequest, DecrementBalance,
                SendGenerationTask
     end
   end

--- a/app/services/telegram_integration/send_answer_callback_query.rb
+++ b/app/services/telegram_integration/send_answer_callback_query.rb
@@ -4,9 +4,10 @@ module TelegramIntegration
       new(...).call
     end
 
-    def initialize(callback_query_id:, button_request:)
+    def initialize(callback_query_id:, button_request: nil, process_name: nil)
       @callback_query_id = callback_query_id
       @button_request = button_request
+      @explicit_process_name = process_name
     end
 
     def call
@@ -15,12 +16,16 @@ module TelegramIntegration
         text: I18n.t("telegram.generation.processing", process_name: humanized_process_name),
         show_alert: false
       )
+    rescue Telegram::Bot::Error
+      nil
     end
 
     private
 
-    attr_reader :callback_query_id, :button_request
+    attr_reader :callback_query_id, :button_request, :explicit_process_name
 
-    delegate :humanized_process_name, to: :button_request
+    def humanized_process_name
+      explicit_process_name || button_request.humanized_process_name
+    end
   end
 end

--- a/spec/app/interactors/media_generator/button_handler/acknowledge_callback_query_spec.rb
+++ b/spec/app/interactors/media_generator/button_handler/acknowledge_callback_query_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe MediaGenerator::ButtonHandler::AcknowledgeCallbackQuery do
+  subject(:result) do
+    described_class.call(
+      callback_query_id:,
+      button_request:,
+      command_request:
+    )
+  end
+
+  let(:callback_query_id) { "callback-123" }
+  let(:user) { create(:user, locale: "en") }
+  let(:command_request) { create(:command_edit_image_request, user:) }
+
+  before do
+    allow(TelegramIntegration::SendAnswerCallbackQuery).to receive(:call)
+  end
+
+  context "when generating cartoon video" do
+    let(:button_request) { ButtonActions::GENERATE_CARTOON_VIDEO }
+
+    it "shows the processing toast immediately" do
+      result
+
+      expect(TelegramIntegration::SendAnswerCallbackQuery)
+        .to have_received(:call)
+        .with(
+          callback_query_id:,
+          process_name: I18n.t(
+            "telegram.generation.humanized_process_names.video.veo3_1_lite_image_to_video",
+            locale: "en"
+          )
+        )
+    end
+  end
+
+  context "when generating cartoon audio" do
+    let(:button_request) { ButtonActions::GENERATE_CARTOON_AUDIO }
+    let(:command_request) { create(:command_prompt_to_video_request, user:) }
+
+    it "shows the processing toast immediately" do
+      result
+
+      expect(TelegramIntegration::SendAnswerCallbackQuery)
+        .to have_received(:call)
+        .with(
+          callback_query_id:,
+          process_name: I18n.t(
+            "telegram.generation.humanized_process_names.audio.voices.lulu_lollipop",
+            locale: "en"
+          )
+        )
+    end
+  end
+
+  context "when callback_query_id is blank" do
+    let(:button_request) { ButtonActions::GENERATE_CARTOON_VIDEO }
+    let(:callback_query_id) { nil }
+
+    it "does not call Telegram" do
+      result
+
+      expect(TelegramIntegration::SendAnswerCallbackQuery).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/app/interactors/media_generator/button_handler/handle_generate_cartoon_video_button_spec.rb
+++ b/spec/app/interactors/media_generator/button_handler/handle_generate_cartoon_video_button_spec.rb
@@ -50,6 +50,24 @@ describe MediaGenerator::ButtonHandler::HandleGenerateCartoonVideoButton do
     allow(TelegramIntegration::SendAnswerCallbackQuery).to receive(:call)
   end
 
+  it "shows the processing toast before script generation" do
+    allow(ScriptGenerator::ForCartoon::ProcessScriptVideoPrompt).to receive(:call).and_wrap_original do |method, **args|
+      expect(TelegramIntegration::SendAnswerCallbackQuery)
+        .to have_received(:call)
+        .with(
+          callback_query_id: "callback-123",
+          process_name: I18n.t(
+            "telegram.generation.humanized_process_names.video.veo3_1_lite_image_to_video",
+            locale: user.locale
+          )
+        )
+
+      method.call(**args)
+    end
+
+    result
+  end
+
   it "creates a veo video request and enqueues generation" do
     expect { result }
       .to change(ButtonVideoProcessingRequest, :count).by(1)

--- a/spec/app/services/telegram_integration/send_answer_callback_query_spec.rb
+++ b/spec/app/services/telegram_integration/send_answer_callback_query_spec.rb
@@ -24,4 +24,31 @@ describe TelegramIntegration::SendAnswerCallbackQuery do
 
     subject
   end
+
+  context "when process_name is provided directly" do
+    subject { described_class.call(callback_query_id:, process_name: "Veo 3.1 Lite video") }
+
+    it "uses the provided process name in the toast" do
+      expected_text = I18n.t("telegram.generation.processing", process_name: "Veo 3.1 Lite video")
+
+      expect(bot).to receive(:answer_callback_query).with(
+        callback_query_id:,
+        text: expected_text,
+        show_alert: false
+      )
+
+      subject
+    end
+  end
+
+  context "when Telegram rejects the callback query" do
+    before do
+      allow(bot).to receive(:answer_callback_query)
+        .and_raise(Telegram::Bot::Error, "query is too old")
+    end
+
+    it "does not raise" do
+      expect { subject }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
**Problem**:
When user clicks on generate video button, there is a 500 error. Why? Because what happens after the button click takes too long. Why? Because if it's admin, sometimes we wait for chatgpt response to create the video_prompt, then we save it, then we create a record, then we make a request to Fal. While this long part is being executed, telegram button continues waiting and spinning. That's why we need to add SendAnswerCallbackQuery, stopping telegram from waiting. 