### PR TITLE
Error message should be referencing the original message

### DIFF
--- a/app/jobs/generator/media/error_notifier_base_job.rb
+++ b/app/jobs/generator/media/error_notifier_base_job.rb
@@ -18,9 +18,7 @@ module Generator
 
       attr_reader :button_request_id, :error_reason
 
-      delegate :chat_id, :locale, :parent_request, to: :request
-      delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
-      delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
+      delegate :chat_id, :locale, to: :request
 
       def custom_error_text
         return if error_reason.blank?
@@ -45,7 +43,7 @@ module Generator
       end
 
       def original_prompt_message_id
-        parent_request_bot_telegram_message_tg_message_id
+        request.origin_telegram_message_id
       end
 
       memoize def request

--- a/app/jobs/generator/media/freepik_empty_alert_base_job.rb
+++ b/app/jobs/generator/media/freepik_empty_alert_base_job.rb
@@ -18,9 +18,7 @@ module Generator
 
       attr_reader :button_request_id
 
-      delegate :chat_id, :locale, :user, :cost, :parent_request, to: :request
-      delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
-      delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
+      delegate :chat_id, :locale, :user, :cost, to: :request
 
       def error_text
         raise NotImplementedError
@@ -39,7 +37,7 @@ module Generator
       end
 
       def original_prompt_message_id
-        parent_request_bot_telegram_message_tg_message_id
+        request.origin_telegram_message_id
       end
 
       memoize def request

--- a/app/models/button_audio_processing_request.rb
+++ b/app/models/button_audio_processing_request.rb
@@ -1,5 +1,6 @@
 class ButtonAudioProcessingRequest < ApplicationRecord
   include HasOriginPrompt
+  include HasOriginTelegramMessage
 
   PROCESSOR_TYPES = %w[elevenlabs_v3_audio].freeze
   VOICE_TYPES = Audio::VoiceCatalog.slugs.map(&:to_s).freeze

--- a/app/models/button_extend_prompt_request.rb
+++ b/app/models/button_extend_prompt_request.rb
@@ -1,5 +1,6 @@
 class ButtonExtendPromptRequest < ApplicationRecord
   include HasOriginPrompt
+  include HasOriginTelegramMessage
 
   belongs_to :parent_request, polymorphic: true
   belongs_to :command_request, polymorphic: true

--- a/app/models/button_image_processing_request.rb
+++ b/app/models/button_image_processing_request.rb
@@ -1,5 +1,6 @@
 class ButtonImageProcessingRequest < ApplicationRecord
   include HasOriginPrompt
+  include HasOriginTelegramMessage
 
   PROCESSOR_TYPES = Generator::Processors::ALL_IMAGE.freeze
 

--- a/app/models/button_video_processing_request.rb
+++ b/app/models/button_video_processing_request.rb
@@ -1,6 +1,7 @@
 class ButtonVideoProcessingRequest < ApplicationRecord
   include HasOriginPrompt
   include HasOriginImage
+  include HasOriginTelegramMessage
 
   PROCESSOR_TYPES = %w[
     kling_2_1_pro_image_to_video

--- a/app/models/concerns/has_origin_telegram_message.rb
+++ b/app/models/concerns/has_origin_telegram_message.rb
@@ -1,0 +1,34 @@
+module HasOriginTelegramMessage
+  extend ActiveSupport::Concern
+
+  def origin_telegram_message_id
+    each_origin_parent_request do |req|
+      message_id = telegram_message_id_for(req)
+      return message_id if message_id.present?
+    end
+
+    nil
+  end
+
+  private
+
+  def each_origin_parent_request
+    req = parent_request_of(self)
+
+    while req
+      yield req
+
+      req = parent_request_of(req)
+    end
+  end
+
+  def parent_request_of(req)
+    req.respond_to?(:parent_request) ? req.parent_request : nil
+  end
+
+  def telegram_message_id_for(req)
+    return unless req.respond_to?(:bot_telegram_message)
+
+    req.bot_telegram_message&.tg_message_id
+  end
+end

--- a/app/services/generator/media/audio/notify_success/send_telegram_message.rb
+++ b/app/services/generator/media/audio/notify_success/send_telegram_message.rb
@@ -24,9 +24,7 @@ module Generator::Media::Audio::NotifySuccess
 
     attr_reader :reply_data, :request
 
-    delegate :locale, :parent_request, to: :request
-    delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
-    delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
+    delegate :locale, to: :request
 
     def reply_data_with_reply_reference
       return reply_data unless original_prompt_message_id.present?
@@ -35,7 +33,7 @@ module Generator::Media::Audio::NotifySuccess
     end
 
     def original_prompt_message_id
-      parent_request_bot_telegram_message_tg_message_id
+      request.origin_telegram_message_id
     end
   end
 end

--- a/app/services/generator/media/image/notify_success/send_telegram_message.rb
+++ b/app/services/generator/media/image/notify_success/send_telegram_message.rb
@@ -24,9 +24,7 @@ module Generator::Media::Image::NotifySuccess
 
     attr_reader :reply_data, :request
 
-    delegate :locale, :parent_request, to: :request
-    delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
-    delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
+    delegate :locale, to: :request
 
     def reply_data_with_reply_reference
       return reply_data unless original_prompt_message_id.present?
@@ -35,7 +33,7 @@ module Generator::Media::Image::NotifySuccess
     end
 
     def original_prompt_message_id
-      parent_request_bot_telegram_message_tg_message_id
+      request.origin_telegram_message_id
     end
   end
 end

--- a/app/services/generator/media/prompt/notify_success/send_telegram_message.rb
+++ b/app/services/generator/media/prompt/notify_success/send_telegram_message.rb
@@ -24,9 +24,7 @@ module Generator::Media::Prompt::NotifySuccess
 
     attr_reader :reply_data, :request
 
-    delegate :locale, :parent_request, to: :request
-    delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
-    delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
+    delegate :locale, to: :request
 
     def reply_data_with_reply_reference
       return reply_data unless original_prompt_message_id.present?
@@ -35,7 +33,7 @@ module Generator::Media::Prompt::NotifySuccess
     end
 
     def original_prompt_message_id
-      parent_request_bot_telegram_message_tg_message_id
+      request.origin_telegram_message_id
     end
   end
 end

--- a/app/services/generator/media/video/notify_success/send_telegram_message.rb
+++ b/app/services/generator/media/video/notify_success/send_telegram_message.rb
@@ -24,9 +24,7 @@ module Generator::Media::Video::NotifySuccess
 
     attr_reader :reply_data, :request
 
-    delegate :locale, :parent_request, to: :request
-    delegate :bot_telegram_message, to: :parent_request, prefix: true, allow_nil: true
-    delegate :tg_message_id, to: :parent_request_bot_telegram_message, prefix: true, allow_nil: true
+    delegate :locale, to: :request
 
     def reply_data_with_reply_reference
       return reply_data unless original_prompt_message_id.present?
@@ -35,7 +33,7 @@ module Generator::Media::Video::NotifySuccess
     end
 
     def original_prompt_message_id
-      parent_request_bot_telegram_message_tg_message_id
+      request.origin_telegram_message_id
     end
   end
 end

--- a/spec/app/jobs/generator/media/video/error_notifier_job_spec.rb
+++ b/spec/app/jobs/generator/media/video/error_notifier_job_spec.rb
@@ -29,6 +29,47 @@ describe Generator::Media::Video::ErrorNotifierJob do
       end
     end
 
+    context "when origin message is on an ancestor request" do
+      let(:command_request) { create(:command_edit_image_request) }
+      let(:image_request) do
+        create(
+          :button_image_processing_request,
+          :completed,
+          command_request:,
+          parent_request: command_request
+        )
+      end
+      let(:prompt_message) do
+        create(
+          :prompt_message,
+          command_request:,
+          parent_request: image_request
+        )
+      end
+      let(:button_request) do
+        create(
+          :button_video_processing_request,
+          status: "PENDING",
+          command_request: create(:command_prompt_to_video_request, user: command_request.user),
+          parent_request: prompt_message
+        )
+      end
+
+      before do
+        create(:bot_telegram_message, request: image_request, tg_message_id: 6280)
+      end
+
+      it "sends telegram message with reply_to_message_id" do
+        expect(telegram_bot).to receive(:send_message).with(
+          chat_id: button_request.chat_id,
+          text: I18n.t("errors.video_generating_error"),
+          reply_to_message_id: 6280
+        )
+
+        perform_job
+      end
+    end
+
     context "when parent request has no bot telegram message" do
       it "sends telegram message without reply_to_message_id" do
         expect(telegram_bot).to receive(:send_message).with(

--- a/spec/app/services/generator/media/video/notify_success/send_telegram_message_spec.rb
+++ b/spec/app/services/generator/media/video/notify_success/send_telegram_message_spec.rb
@@ -34,6 +34,47 @@ describe Generator::Media::Video::NotifySuccess::SendTelegramMessage do
       end
     end
 
+    context "when source telegram message is on an ancestor request" do
+      let(:command_request) { create(:command_edit_image_request) }
+      let(:image_request) do
+        create(
+          :button_image_processing_request,
+          :completed,
+          command_request:,
+          parent_request: command_request
+        )
+      end
+      let(:prompt_message) do
+        create(
+          :prompt_message,
+          command_request:,
+          parent_request: image_request
+        )
+      end
+      let(:request) do
+        create(
+          :button_video_processing_request,
+          command_request: create(:command_prompt_to_video_request, user: command_request.user),
+          parent_request: prompt_message
+        )
+      end
+
+      before do
+        create(:bot_telegram_message, request: image_request, tg_message_id: 6280)
+      end
+
+      it "sends telegram message as reply" do
+        call_service
+
+        expect(TelegramIntegration::SendMessageWithButtons)
+          .to have_received(:call)
+          .with(
+            reply_data: reply_data.merge(reply_to_message_id: 6280),
+            request:
+          )
+      end
+    end
+
     context "when source telegram message does not exist" do
       it "sends telegram message without reply reference" do
         call_service

--- a/spec/models/concerns/has_origin_telegram_message_spec.rb
+++ b/spec/models/concerns/has_origin_telegram_message_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe HasOriginTelegramMessage do
+  subject(:origin_telegram_message_id) { request.origin_telegram_message_id }
+
+  let(:command_request) { create(:command_edit_image_request) }
+  let(:image_request) do
+    create(
+      :button_image_processing_request,
+      :completed,
+      command_request:,
+      parent_request: command_request
+    )
+  end
+  let(:prompt_message) do
+    create(
+      :prompt_message,
+      command_request:,
+      parent_request: image_request
+    )
+  end
+  let(:request) do
+    create(
+      :button_video_processing_request,
+      command_request: create(:command_prompt_to_video_request, user: command_request.user),
+      parent_request: prompt_message
+    )
+  end
+
+  context "when a parent in the chain has a bot telegram message" do
+    before do
+      create(:bot_telegram_message, request: image_request, tg_message_id: 6280)
+    end
+
+    it "returns the origin message id" do
+      expect(origin_telegram_message_id).to eq(6280)
+    end
+  end
+
+  context "when no parent in the chain has a bot telegram message" do
+    it "returns nil" do
+      expect(origin_telegram_message_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
“Sorry, I couldn’t generate the video. Please try again later.“ should reference the origin message. Also, I moved origin_telegram_message logics to concern. 