### PR TITLE
Fix bug with re-generating videos in cartoon flow

### DIFF
--- a/app/interactors/media_generator/button_handler/validate_cartoon_video_script_request.rb
+++ b/app/interactors/media_generator/button_handler/validate_cartoon_video_script_request.rb
@@ -15,8 +15,6 @@ module MediaGenerator
         context.fail!(error: CommandUnknownError)
       end
 
-      private
-
       delegate :origin_video_prompt, to: :parent_request, allow_nil: true
       delegate :script, to: :origin_video_prompt, allow_nil: true
 

--- a/app/interactors/media_generator/button_handler/validate_cartoon_video_script_request.rb
+++ b/app/interactors/media_generator/button_handler/validate_cartoon_video_script_request.rb
@@ -6,24 +6,21 @@ module MediaGenerator
 
       delegate :command_request, :parent_request, to: :context
 
-      # parent_request is a ButtonVideoProcessingRequest
-      # the request tied to the message the button was pressed on
-      delegate :prompt_message, to: :parent_request
-      delegate :video_prompt, to: :prompt_message
-      delegate :script, to: :video_prompt
-
-      memoize :prompt_message, :video_prompt, :script
-
-      private :prompt_message, :video_prompt, :script
-
       def call
         context.script = script
-        context.video_prompt = video_prompt
+        context.video_prompt = origin_video_prompt
 
         return if command_request.cartoon_script? && script.present?
 
         context.fail!(error: CommandUnknownError)
       end
+
+      private
+
+      delegate :origin_video_prompt, to: :parent_request, allow_nil: true
+      delegate :script, to: :origin_video_prompt, allow_nil: true
+
+      memoize :origin_video_prompt, :script
     end
   end
 end

--- a/app/models/button_video_processing_request.rb
+++ b/app/models/button_video_processing_request.rb
@@ -2,6 +2,7 @@ class ButtonVideoProcessingRequest < ApplicationRecord
   include HasOriginPrompt
   include HasOriginImage
   include HasOriginTelegramMessage
+  include HasOriginVideoPrompt
 
   PROCESSOR_TYPES = %w[
     kling_2_1_pro_image_to_video

--- a/app/models/concerns/has_origin_video_prompt.rb
+++ b/app/models/concerns/has_origin_video_prompt.rb
@@ -1,0 +1,36 @@
+module HasOriginVideoPrompt
+  # which cartoon scene am I part of?
+
+  extend ActiveSupport::Concern
+
+  def origin_video_prompt
+    each_video_prompt_parent_request do |req|
+      video_prompt = video_prompt_for(req)
+      return video_prompt if video_prompt.present?
+    end
+
+    nil
+  end
+
+  private
+
+  def each_video_prompt_parent_request
+    req = parent_request_of(self)
+
+    while req
+      yield req
+
+      req = parent_request_of(req)
+    end
+  end
+
+  def parent_request_of(req)
+    req.respond_to?(:parent_request) ? req.parent_request : nil
+  end
+
+  def video_prompt_for(req)
+    return unless req.is_a?(PromptMessage)
+
+    req.video_prompt
+  end
+end

--- a/spec/app/interactors/media_generator/button_handler/validate_cartoon_video_script_request_spec.rb
+++ b/spec/app/interactors/media_generator/button_handler/validate_cartoon_video_script_request_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+describe MediaGenerator::ButtonHandler::ValidateCartoonVideoScriptRequest do
+  subject(:result) { described_class.call(context) }
+
+  let(:command_request) do
+    create(:command_prompt_to_video_request, category: ContentCategory::CARTOON_SCRIPT)
+  end
+  let(:video_prompt) { create(:video_prompt, prompt: "Camera slowly zooms in as Bloomy waves.") }
+  let(:script) { create(:script, script_text: "Bloomy waves hello.", video_prompt:) }
+  let(:prompt_message) do
+    create(:prompt_message, prompt: video_prompt.prompt, video_prompt:, command_request:)
+  end
+  let(:parent_request) do
+    create(
+      :button_video_processing_request,
+      :completed,
+      command_request:,
+      parent_request: prompt_message,
+      processor: "veo3_1_lite_image_to_video"
+    )
+  end
+  let(:context) do
+    Interactor::Context.build(
+      command_request:,
+      parent_request:
+    )
+  end
+
+  before { script unless script.nil? }
+
+  it "succeeds and sets script and video_prompt on context" do
+    expect(result).to be_success
+    expect(result.script).to eq(script)
+    expect(result.video_prompt).to eq(video_prompt)
+  end
+
+  context "when parent is a regenerated video request" do
+    let(:parent_request) do
+      create(
+        :button_video_processing_request,
+        :completed,
+        command_request:,
+        parent_request: create(
+          :button_video_processing_request,
+          :completed,
+          command_request:,
+          parent_request: prompt_message,
+          processor: "veo3_1_lite_image_to_video"
+        ),
+        processor: "veo3_1_lite_image_to_video"
+      )
+    end
+
+    it "succeeds using the ancestor prompt message" do
+      expect(result).to be_success
+      expect(result.script).to eq(script)
+      expect(result.video_prompt).to eq(video_prompt)
+    end
+  end
+
+  context "when script is missing" do
+    let(:script) { nil }
+
+    it "fails with CommandUnknownError" do
+      expect(result).to be_failure
+      expect(result.error).to eq(CommandUnknownError)
+    end
+  end
+end

--- a/spec/app/models/button_video_processing_request_spec.rb
+++ b/spec/app/models/button_video_processing_request_spec.rb
@@ -77,7 +77,7 @@ describe ButtonVideoProcessingRequest, type: :model do
     let(:prompt_message) { create(:prompt_message) }
     let(:record) { create(:button_video_processing_request, parent_request: prompt_message) }
 
-    it "returns the parent prompt message" do
+    it "returns the immediate parent request" do
       expect(record.prompt_message).to eq(prompt_message)
     end
   end

--- a/spec/models/concerns/has_origin_video_prompt_spec.rb
+++ b/spec/models/concerns/has_origin_video_prompt_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe HasOriginVideoPrompt do
+  subject(:origin_video_prompt) { request.origin_video_prompt }
+
+  let(:command_request) do
+    create(:command_prompt_to_video_request, category: ContentCategory::CARTOON_SCRIPT)
+  end
+  let(:video_prompt) { create(:video_prompt) }
+  let(:prompt_message) { create(:prompt_message, video_prompt:, command_request:) }
+  let(:request) do
+    create(
+      :button_video_processing_request,
+      command_request:,
+      parent_request: prompt_message
+    )
+  end
+
+  it "returns the video prompt from an ancestor prompt message" do
+    expect(origin_video_prompt).to eq(video_prompt)
+  end
+
+  context "when parent is a regenerated video request" do
+    let(:request) do
+      create(
+        :button_video_processing_request,
+        command_request:,
+        parent_request: create(
+          :button_video_processing_request,
+          command_request:,
+          parent_request: prompt_message
+        )
+      )
+    end
+
+    it "returns the video prompt from the ancestor prompt message" do
+      expect(origin_video_prompt).to eq(video_prompt)
+    end
+  end
+
+  context "when no ancestor prompt message has a video prompt" do
+    let(:prompt_message) { create(:prompt_message, command_request:) }
+
+    it "returns nil" do
+      expect(origin_video_prompt).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
There was an error in this user case:
1) Generate cartoon_script
2) Generate video
3) Regenerate video
4) Generate audio fro video from step 3

Get this error:

```

NoMethodError (undefined method `video_prompt' for an instance of ButtonVideoProcessingRequest)

app/interactors/media_generator/button_handler/validate_cartoon_video_script_request.rb:12:in `video_prompt'

```

It happens because video_prompt was not present in regenerated Video, since it's parent was ButtonVideoProcessingRequest, not VideoPrompt